### PR TITLE
Document domain interfaces and add frontend contracts

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -36,6 +36,15 @@
 - `di` связывает реализации и интерфейсы между всеми слоями, но сами пакеты не зависят от `di`.
 - `util` доступен как вспомогательный пакет для всех остальных уровней.
 
+## Интерфейсы и границы
+
+| Интерфейс | Владелец | Основные методы | Направление зависимостей |
+|-----------|----------|-----------------|--------------------------|
+| `GameSessionGateway` | `domain` | `startNewSession`, `submitMove`, `observeSession` | `ui` вызывает `domain`, `data` реализует контракт |
+| `PlayerProfileRepository` | `domain` | `getProfile`, `updateProfile` | `ui`/`domain` используют, `data` предоставляет реализацию |
+| `LeaderboardRepository` | `domain` | `getLeaderboard`, `refreshLeaderboard` | `ui`/`domain` используют, `data` реализует с доступом к сетевым и локальным источникам |
+| `AuthGateway` | `domain` | `authenticate`, `logout`, `restoreSession` | `ui`/`integration` зависят от `domain`, реализации находятся в `data` |
+
 ## Диаграмма зависимостей
 
 ```mermaid

--- a/frontend/app/src/domain/AuthGateway.ts
+++ b/frontend/app/src/domain/AuthGateway.ts
@@ -1,0 +1,17 @@
+export interface AuthGateway {
+  /**
+   * Performs user authentication and returns an access token when successful.
+   * @param credentials Login payload such as username/password or social token.
+   */
+  authenticate(credentials: Record<string, unknown>): Promise<{ token: string }>;
+
+  /**
+   * Clears authentication state and revokes associated tokens.
+   */
+  logout(): Promise<void>;
+
+  /**
+   * Restores the currently authenticated session if available.
+   */
+  restoreSession(): Promise<{ token: string } | null>;
+}

--- a/frontend/app/src/domain/GameSessionGateway.ts
+++ b/frontend/app/src/domain/GameSessionGateway.ts
@@ -1,0 +1,24 @@
+export interface GameSessionGateway {
+  /**
+   * Starts a new game session for the provided participant(s).
+   * @param params Identifiers and configuration required to create the session.
+   */
+  startNewSession(params: { playerIds: string[]; seed?: string }): Promise<string>;
+
+  /**
+   * Submits a player move to the active session.
+   * @param params Contains session identifier and the move payload.
+   */
+  submitMove(params: { sessionId: string; move: unknown }): Promise<void>;
+
+  /**
+   * Subscribes to state updates for the given session.
+   * @param sessionId Identifier of the session to observe.
+   * @param listener Callback invoked for each state change.
+   * @returns A disposer that detaches the listener when called.
+   */
+  observeSession(
+    sessionId: string,
+    listener: (state: unknown) => void
+  ): () => void;
+}

--- a/frontend/app/src/domain/LeaderboardRepository.ts
+++ b/frontend/app/src/domain/LeaderboardRepository.ts
@@ -1,0 +1,12 @@
+export interface LeaderboardRepository {
+  /**
+   * Retrieves leaderboard entries sorted according to the specified strategy.
+   * @param params Filters and pagination details.
+   */
+  getLeaderboard(params?: { limit?: number; offset?: number; scope?: string }): Promise<unknown[]>;
+
+  /**
+   * Forces a refresh of cached leaderboard data.
+   */
+  refreshLeaderboard(scope?: string): Promise<void>;
+}

--- a/frontend/app/src/domain/PlayerProfileRepository.ts
+++ b/frontend/app/src/domain/PlayerProfileRepository.ts
@@ -1,0 +1,14 @@
+export interface PlayerProfileRepository {
+  /**
+   * Loads the profile for a specific player.
+   * @param playerId Unique identifier of the player whose profile should be fetched.
+   */
+  getProfile(playerId: string): Promise<unknown>;
+
+  /**
+   * Persists profile changes such as nickname or avatar.
+   * @param playerId Identifier of the player being updated.
+   * @param payload Key-value pairs representing profile fields to be stored.
+   */
+  updateProfile(playerId: string, payload: Record<string, unknown>): Promise<void>;
+}


### PR DESCRIPTION
## Summary
- add an interface ownership table to the architecture documentation
- scaffold domain contracts for the frontend so UI can depend on stable boundaries

## Testing
- not run (documentation and interface stubs only)


------
https://chatgpt.com/codex/tasks/task_e_6901f49319708333a001a74a560dba8e