### PR TITLE
Document Java backend migration and VS Code workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,163 +1,165 @@
-# Игра "Камень - Ножницы - Бумага"
+# Zazeks: Rock–Paper–Scissors with Gesture Recognition
 
-Добро пожаловать в репозиторий проекта "Камень - Ножницы - Бумага"! Данный проект представляет собой игру, в которой пользователь соревнуется с компьютером, используя реальные жесты, определяемые с помощью нейронной сети.
-
----
-
-## Описание проекта
-
-**Кейс:** Разработка игры "Камень - Ножницы - Бумага", в которой:
-- Пользователь играет против компьютера.
-- Программа получает изображение с камеры, распознаёт один из трех жестов:
-  - **Камень**
-  - **Ножницы**
-  - **Бумага**
-- Компьютер генерирует случайный выбор из этих же вариантов.
-- На основе общепринятых правил:
-  - Ножницы побеждают бумагу.
-  - Бумага побеждает камень.
-  - Камень побеждает ножницы.
-- Результат сравнения выводится на экран с сообщением **"Победа"** или **"Проигрыш"**.
-- Программа ведет учёт количества побед и поражений игрока.
+This repository contains the in-progress migration of the Zazeks gesture-driven Rock–Paper–Scissors game from a Python/FastAPI backend to a Spring Boot backend paired with the existing Android client. The goal is to provide the same real-time gameplay, matchmaking, and player management features that the FastAPI stack exposed while simplifying local development.
 
 ---
 
-## Функциональные возможности
+## Project layout
 
-- **Реальное распознавание жестов:** 
-  - Использование камеры для захвата изображения в реальном времени.
-  - Детекция жестов (камень, ножницы, бумага) с помощью дообученной модели YOLOv11.
-- **Дополнительные возможности:**
-  - **Мультиплеер:** Возможность игры между двумя игроками.
-  - **Профиль игрока:** Хранение статистики, количества побед и поражений.
-- **Гибкий интерфейс:**
-  - Игра реализована в виде многофункциональной веб-страницы.
-
----
-
-## Используемые технологии
-
-- **Нейронные сети и компьютерное зрение:**
-  - Модель YOLOv11, дообученная на собственном датасете из 12,000 изображений.
-- **Основные фреймворки:**
-  - YOLO, FastApi
-  - Spring Boot 3 (Java backend, WebSocket)
-- **Интерфейс:**
-  - Html, css, JavaScript.
+| Path | Description |
+|------|-------------|
+| `java-backend/` | Spring Boot 3 service that currently backs the game APIs and multiplayer WebSocket. |
+| `android/` | Android client written in Java with HTTP/WebSocket integrations and configurable backend endpoints. |
+| `backend/` | Legacy FastAPI service kept only as a reference for feature parity. |
+| `docs/` | High-level architecture notes, testing strategy, and demo scripts. |
+| `model/`, `defay_1x9/`, `frontend/` | Assets from the original prototype (not yet integrated with the Java backend). |
 
 ---
 
-## Установка и запуск
+## Current status and remaining work
 
-1. **Клонируйте репозиторий:**
+### Spring Boot backend
 
-   ```bash
-   git clone https://github.com/BeesKnigh/zazeks.git
-   cd zazeks
+**Implemented**
+- JWT-based authentication with registration/login endpoints.
+- Player profile, avatar, and leaderboard operations backed by an in-memory data store.
+- REST CRUD for single-player game history plus duplicate-submission protection.
+- WebSocket matchmaking (`/ws/multiplayer`) with battle lifecycle management and result persistence.
+- Administrative actions for moderating users and game records.
 
-2. **Создайте виртуальное окружение и войдите в него**
-    ``` bash
-    python -m venv venv
-    venv\Scripts\activate
+**To be reimplemented before feature parity**
+- Replace the in-memory database with the PostgreSQL schema that existed in the FastAPI service.
+- Persist avatars and other binary assets outside of process memory.
+- Restore ML-powered inference for `/model/detect` (the current implementation returns a deterministic hash-based stub).
+- Reintroduce analytics/log streaming and structured audit trails from the Python stack.
 
-2. **Установите необходимые зависимости:**
-    ```bash
-    pip install -r requirements.txt
+### Android client
 
-3. **Запуск backend части:**
-    ```bash
-    uvicorn --app-dir backend src.main:app
+**Implemented**
+- Connects to configurable HTTP/WebSocket endpoints for authentication, play, and leaderboards.
+- Streams camera frames to `/model/detect` and renders bounding boxes/gesture results when provided.
+- Includes debug and release signing configuration templates.
 
-4. **Запуск backend части:**
- - Все можно заходить на сайт и играть оффлайн:
-    ```bash
-    http://127.0.0.1:8000
+**To be reimplemented**
+- Switch the HTTP bridge to the restored Java inference service or enable on-device TensorFlow Lite once the backend endpoint is updated.
+- Re-enable offline caching and background sync that depended on the FastAPI endpoints.
+- Update UI copy/screenshots after parity testing with the new backend.
 
-### Java backend (полная функциональность FastAPI версии)
-
-В каталоге `java-backend` находится эквивалентный сервер на Spring Boot 3, который реализует все маршруты, WebSocket-поток и административные операции, доступные ранее в Python/FastAPI.
-
-- **Запуск:**
-  ```bash
-  cd java-backend
-  ./gradlew bootRun
-  ```
-- **Возможности:** REST-эндпоинты авторизации, профилей, истории игр, админ-панели, сохранения результатов мультиплеера и WebSocket `/ws/multiplayer` для матчмейкинга и боёв.
-- **Тесты:**
-  ```bash
-  ./gradlew test
-  ```
-  Набор интеграционных тестов покрывает защиту от повторной отправки игр, проверки ролей и полный жизненный цикл WebSocket-сессий.
+Legacy FastAPI code remains available for comparison during the migration but should not be deployed for new development.
 
 ---
 
-## Использование
-- Запуск игры: После старта приложения, направьте камеру на руку, демонстрирующую один из жестов (камень, ножницы или бумага).
-- Соревнование: Приложение автоматически сравнит выбранный жест с выбором компьютера и определит победителя.
-- Статистика: В профиле и лидерборде можно увидеть всю статистику которая у вас записывается.
+## Backend API surface (Spring Boot)
+
+All endpoints expect JSON unless stated otherwise. Authenticated routes require an `Authorization: Bearer <token>` header obtained from `POST /auth/login`.
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/auth/register` | Create a player with username, password, optional Base64 avatar. |
+| `POST` | `/auth/login` | Obtain a JWT for subsequent requests. |
+| `GET` | `/users/leaderboard/offline` | Offline leaderboard sorted by total wins. |
+| `GET` | `/users/leaderboard/online` | Online leaderboard sorted by multiplayer wins. |
+| `GET` | `/users/{userId}` | Fetch the authenticated player’s profile and statistics. |
+| `GET` | `/users/{userId}/avatar` | Retrieve the player avatar as a Base64 string. |
+| `PUT` | `/users/{userId}` | Update username and/or avatar. |
+| `POST` | `/games` | Save a single-player match result. |
+| `GET` | `/games/{gameId}` | Retrieve a specific single-player match. |
+| `GET` | `/games/user/{userId}` | List matches for the authenticated player. |
+| `PUT` | `/games/add-win/{userId}` | Increment the win counter (utility action used by the client). |
+| `POST` | `/multiplayer/result` | Persist a multiplayer match result. |
+| `POST` | `/model/detect` | Upload a JPEG frame for gesture detection (stubbed until ML integration returns). |
+| `DELETE` | `/admin/users/{userId}` | Remove a non-admin user. |
+| `POST` | `/admin/admins` | Grant admin role to a user. |
+| `DELETE` | `/admin/admins/{userId}` | Revoke admin role. |
+| `DELETE` | `/admin/games/{gameId}` | Delete any recorded game. |
+| `DELETE` | `/admin/users/{userId}/photo` | Remove avatar media. |
+| `PUT` | `/admin/users/{userId}/username` | Force-update a username. |
+| `WS` | `/ws/multiplayer` | Matchmaking and game orchestration for multiplayer battles. |
+
+Swagger/OpenAPI generation has not been wired up yet; use the integration tests in `java-backend/src/test/java` as executable documentation.
 
 ---
 
-## Мобильное приложение (Android)
+## Running the backend
 
-Подробная инструкция по сборке и запуску мобильной версии расположена в `android/README.md`. В ней
-описаны:
+```
+cd java-backend
+# First-time setup: ensure the Gradle wrapper JAR is downloaded.
+./gradlew wrapper
+# Start the Spring Boot service (equivalent to the legacy FastAPI app).
+./gradlew bootRun
+```
 
-- настройка Gradle и подписи debug/release сборок с использованием собственного keystore (шаблон в `android/signing/signing.properties.example`);
-- набор файлов, упакованных в APK (конфигурации backend, демо-модель и вспомогательные ресурсы);
-- команды для сборки, установки и проверки APK;
-- демонстрационный сценарий (см. `docs/android/demo_script.md`).
+The service listens on <http://localhost:8080>. Configuration such as JWT lifetimes reads from environment variables via `com.zazeks.config.Settings`.
+
+During development you can reset the in-memory store between manual tests by restarting the process.
 
 ---
 
-## 🐟 Команда разработчиков
+## Android client quick start
 
-<table>
-  <tr>
-    <td align="center" style="border: 1px solid #555;">
-      <img src="defay_1x9/pics_readme/Sasha.jpg" width="100" height="100" style="border-radius: 50%" alt="avatar"><br />
-      <b>Александр Штеренфельд</b><br />
-      <sub><i>Тимлид, ML Developer ,Full-stack разработчик</i></sub>
-      <hr style="border: 1px solid #555; margin: 10px 0;">
-      <div align="left">
-      <b>Вклад в проект:</b><br />
-      • Backend/Frontend разработка<br />
-      • Работа с базами данных<br />
-      • Модель по распознованию жестов
-      <hr style="border: 1px solid #555; margin: 10px 0;">
-      <b>Контакты:</b><br />
-      <a href="https://github.com/BeesKnigh">GitHub</a> • <a href="https://t.me/BeesKnights">Telegram</a>
-      </div>
-    </td>
-    <td align="center" style="border: 1px solid #555;">
-      <img src="defay_1x9/pics_readme/Denis.jpg" width="100" height="100" style="border-radius: 50%" alt="avatar"><br />
-      <b>Денис Байрамов</b><br />
-      <sub><i>Backend разработчик</i></sub>
-      <hr style="border: 1px solid #555; margin: 10px 0;">
-      <div align="left">
-      <b>Вклад в проект:</b><br />
-      • Backend разработка<br />
-      • Работа с базами данных<br />
-      <hr style="border: 1px solid #555; margin: 10px 0;">
-      <b>Контакты:</b><br />
-      <a href="https://github.com/Denbay0">GitHub</a> • <a href="https://t.me/Denbay0">Telegram</a>
-      </div>
-    </td>
-    <td align="center" style="border: 1px solid #555;">
-      <img src="defay_1x9/pics_readme/Max.jpg" width="100" height="100" style="border-radius: 50%" alt="avatar"><br />
-      <b>Максим Землянский</b><br />
-      <sub><i>Pintester</i></sub>
-      <hr style="border: 1px solid #555; margin: 10px 0;">
-      <div align="left">
-      <b>Вклад в проект:</b><br />
-      • Безпосаность<br />
-      • Придумывал проблемы<br />
-      <hr style="border: 1px solid #555; margin: 10px 0;">
-      <b>Контакты:</b><br />
-      <a href="https://github.com/kusotsu">GitHub</a> • <a href="https://t.me/kusotsutar">Telegram</a>
-      </div>
-    </td>
-  </tr>
-</table>
+```
+cd android
+# Assemble a debug build
+./gradlew assembleDebug
+# Run JVM unit tests for the Android module
+./gradlew testDebugUnitTest
+```
 
-![alt text](defay_1x9/pics_readme/image.png)
+Update `src/main/assets/config/backend.json` to point the app to your backend instance (see below). Install the resulting APK with `adb install -r build/outputs/apk/debug/android-debug.apk` or by using the VS Code/Android Studio device manager.
+
+The client currently expects the `/model/detect` endpoint to be reachable over HTTP. If you test against the Java backend before the ML rewrite lands, the placeholder inference will respond with pseudo-random gestures derived from the uploaded bytes.
+
+---
+
+## VS Code workflow
+
+1. **Recommended extensions**
+   - *Extension Pack for Java* (includes Language Support for Java, Debugger for Java, and the Gradle Tasks explorer).
+   - *Android Extension Pack* or at least *Android Emulator* + *ADB Interface* so VS Code can surface devices and logcat.
+   - *Kotlin* support is optional but useful for reading Gradle Kotlin DSL files.
+
+2. **Integrated terminal commands**
+   - Backend: `cd java-backend && ./gradlew bootRun` (VS Code exposes this as the `run` task in the Gradle explorer, so you can trigger it with `./gradlew run` from the command palette if you prefer the alias).
+   - Backend tests: `cd java-backend && ./gradlew test`.
+   - Android build: `cd android && ./gradlew assembleDebug`.
+
+   You can add these commands to `.vscode/tasks.json` to launch them with <kbd>Ctrl</kbd>/<kbd>Cmd</kbd>+<kbd>Shift</kbd>+<kbd>B</kbd>. When defining tasks, set the `cwd` to either `java-backend` or `android` to avoid path issues.
+
+3. **Debugging & devices**
+   - Use the Java extension’s *Run and Debug* view to attach to the Spring Boot app. Configure a `Java: Launch` profile pointing at `com.zazeks.app.Application`—VS Code will reuse the Gradle build and allow breakpoints.
+   - Install the *Android* extension’s ADB integration to list physical devices or emulators in the *Devices* panel. Ensure an emulator is running (`Android SDK` tools) or plug in a device with USB debugging enabled.
+   - Create an `android` launch configuration with `"request": "launch"` and `"appSrcRoot": "${workspaceFolder}/android"` so you can trigger `assembleDebug` + deploy directly from VS Code.
+   - For emulator debugging, start an Android Virtual Device (`avdmanager` or Android Studio), then use the *Run on Android* command palette entry supplied by the extension pack.
+
+---
+
+## End-to-end testing from VS Code
+
+The goal is to exercise the full stack—backend REST/WebSocket plus the Android client—in one workspace.
+
+1. **Backend verification**
+   - `cd java-backend && ./gradlew test` runs the JUnit integration suite (`src/test/java/com/zazeks/web/*IntegrationTest.java`), covering REST endpoints, JWT flows, and WebSocket matchmaking. Failures usually highlight parity gaps with the legacy FastAPI behaviour.
+
+2. **Android unit tests**
+   - `cd android && ./gradlew testDebugUnitTest` executes JVM tests for view models, repositories, and HTTP bridges without needing an emulator.
+
+3. **Android UI tests**
+   - `cd android && ./gradlew connectedDebugAndroidTest` requires an emulator or device. Launch the emulator via the VS Code device panel, then trigger the task from the Gradle explorer or a custom task entry.
+
+4. **Smoke-testing the full flow**
+   - Start the backend (`./gradlew bootRun`).
+   - Deploy the debug APK to an emulator using `adb install` or VS Code’s *Run on Android* command.
+   - From the emulator, register a user, play a single-player round, then open matchmaking so the WebSocket traffic is exercised. Watch backend logs in the terminal to confirm game persistence.
+   - For inference checks, upload static images via the in-app gallery until the real model is restored.
+
+Because the backend stores everything in memory, restarting `bootRun` gives you a clean slate for repeated test loops.
+
+---
+
+## Contributing
+
+1. Fork and clone the repository.
+2. Create a feature branch and ensure both backend (`./gradlew test`) and Android (`./gradlew testDebugUnitTest`) checks pass before opening a PR.
+3. Update this README or the Android documentation when you add or change API endpoints so the migration guide stays current.
+

--- a/android/README.md
+++ b/android/README.md
@@ -1,107 +1,98 @@
-# Мобильное приложение Zazeks
+# Zazeks Android app
 
-Этот документ описывает процесс подготовки и сборки Android-приложения проекта, включая
-настройку тестовой подписи, проверку встроенных ресурсов и запуск.
+This guide walks through preparing, configuring, and testing the Android client while the backend migration to Spring Boot is underway.
 
-## Предварительные требования
+## Prerequisites
 
-- Android Studio Iguana (или новее) **или** установленный Gradle 8.5+
-- Android SDK 34, платформа-инструменты и эмулятор/устройство с Android 7.0+
-- Java 17 (рекомендуется использовать комплект JDK, поставляемый с Android Studio)
+- Android Studio Iguana (or newer) **or** the Android command-line tools with Gradle 8.5+
+- Android SDK 34 with platform tools and at least one emulator image (Android 7.0+ supported)
+- Java 17 (use the JDK bundled with Android Studio or Temurin 17)
 
-## Структура проекта
+## Project structure
 
 ```
 android/
-├── build.gradle          # Модульное описание Gradle
-├── signing/              # Настройки подписи (шаблон и ваши ключи)
-├── src/main/assets/      # Ресурсы, конфигурации и модель
-└── src/main/java/...     # Исходный код приложения
+├── build.gradle          # Module-level Gradle file
+├── signing/              # Debug/release signing configuration (template provided)
+├── src/main/assets/      # Backend configuration and ML assets packaged into the APK
+└── src/main/java/...     # Application sources
 ```
 
-Каталог `src/main/assets` содержит пример конфигурации backend, демонстрационные данные модели
-и служебные файлы камеры. Они автоматически упаковываются в APK для режимов debug и release.
+`src/main/assets` ships configuration files such as `config/backend.json`, demo models, and camera presets. They are included in every build variant.
 
-## Настройка подписи APK
+## APK signing
 
-В каталоге `signing/` лежит файл-шаблон `signing.properties.example`.
-Скопируйте его в `signing/signing.properties` и заполните своими данными.
-Если у вас ещё нет keystore, создайте его (например, командой ниже) и пропишите путь и пароли:
+1. Copy `signing/signing.properties.example` to `signing/signing.properties`.
+2. Generate a keystore if you do not already have one:
+   ```bash
+   keytool -genkeypair -v \
+     -storetype PKCS12 \
+     -keystore signing/my-release-key.jks \
+     -alias my-key-alias \
+     -keyalg RSA -keysize 2048 -validity 3650
+   ```
+3. Update `signing/signing.properties` with the keystore path and passwords:
+   ```
+   storeFile=signing/my-release-key.jks
+   storePassword=<keystore password>
+   keyAlias=<key alias>
+   keyPassword=<key password>
+   ```
 
-```bash
-keytool -genkeypair -v \
-  -storetype PKCS12 \
-  -keystore signing/my-release-key.jks \
-  -alias my-key-alias \
-  -keyalg RSA -keysize 2048 -validity 3650
-```
+When the file exists, Gradle signs both debug and release builds automatically.
 
-После генерации укажите значения в `signing/signing.properties`:
+## Backend configuration
 
-```
-storeFile=signing/my-release-key.jks
-storePassword=<пароль к хранилищу>
-keyAlias=<алиас ключа>
-keyPassword=<пароль ключа>
-```
-
-Gradle применит подпись и для debug, и для release сборки, если файл `signing/signing.properties` существует.
-
-## Обновление конфигурации backend
-
-Приложение читает параметры окружения из `src/main/assets/config/backend.json`. Перед сборкой
-обновите адреса под своё окружение. Пример содержимого:
+The app reads connection details from `src/main/assets/config/backend.json`. Point it at the Spring Boot service (default port 8080):
 
 ```json
 {
-  "backendBaseUrl": "http://10.0.2.2:8000",
+  "backendBaseUrl": "http://10.0.2.2:8080",
   "detectionEndpoint": "/model/detect",
   "timeoutSeconds": 15
 }
 ```
 
-Для удобства рядом лежит шаблон `backend.example.json`.
+Use `10.0.2.2` when running on an emulator; physical devices should reference your workstation IP. The detection endpoint stays the same while the Java backend regains ML support. If you experiment with on-device inference, replace `backendBaseUrl` with `"device"` and update the client code to bypass HTTP calls.
 
-## Сборка из командной строки
+## Building from the command line
 
 ```bash
 cd android
-./gradlew assembleDebug   # сборка debug и генерация app-debug.apk
-./gradlew assembleRelease # сборка release и генерация app-release.apk
+./gradlew assembleDebug   # Produces app-debug.apk
+./gradlew assembleRelease # Produces app-release.apk
 ```
 
-> Если Gradle wrapper ещё не инициализирован в вашей среде, запустите `gradle wrapper` один раз или
-> воспользуйтесь Android Studio (она создаст wrapper автоматически).
+> If you are setting up the project on a new machine, run `./gradlew wrapper` once to download the Gradle wrapper JAR.
 
-Готовые APK можно найти в `android/build/outputs/apk/<buildType>/`.
+Outputs appear under `android/build/outputs/apk/<buildType>/`.
 
-## Установка APK на устройство
+## Installing a build
 
-1. Включите режим разработчика и «Отладку по USB» на устройстве.
-2. Подключите устройство к компьютеру и убедитесь, что оно определяется командой `adb devices`.
-3. Установите нужную сборку:
+1. Enable Developer Mode and USB debugging on your device (or boot an emulator).
+2. Verify that the device is visible: `adb devices`.
+3. Install the APK:
    ```bash
    adb install -r build/outputs/apk/debug/android-debug.apk
    ```
-4. Запустите приложение «Zazeks» на устройстве/эмуляторе.
+4. Launch the **Zazeks** app.
 
-## Проверка встроенных файлов
+## Packaging checks
 
-- В Android Studio откройте вкладку *Build* → *Analyze APK* и выберите собранный APK.
-- Убедитесь, что внутри присутствуют каталоги:
-  - `assets/config/backend.json`
-  - `assets/model/gesture_labels.json`
-  - `assets/resources/camera_presets.json`
-- Для автоматизации можно использовать команду `./gradlew verifyReleaseResources`, которая
-  проверит наличие ресурсов на этапе сборки.
+- Android Studio: *Build* → *Analyze APK* to inspect embedded assets (`assets/config/backend.json`, ML labels, camera presets).
+- Command line: `./gradlew verifyReleaseResources` fails the build if required resources are missing.
 
-## Запуск демонстрации
+## Demo flow
 
-1. Убедитесь, что backend (FastAPI) запущен и доступен по адресу, указанному в `backend.json`.
-2. Запустите приложение и выберите «Новая игра» в главном меню.
-3. Нажмите «Старт» — камера активируется и начнёт отправлять кадры в backend.
-4. Показывайте жесты «камень», «ножницы» или «бумага» перед камерой.
-5. Наблюдайте за результатами раунда и статистикой побед в приложении.
-6. Для завершения сеанса вернитесь в главное меню и откройте «Результаты».
+1. Start the Spring Boot backend (`cd ../java-backend && ./gradlew bootRun`).
+2. Launch the app and register a new player.
+3. Play a single-player round to exercise the `/games` endpoint.
+4. Join matchmaking to verify WebSocket connectivity and `/multiplayer/result`.
+5. Observe backend logs for saved games; restart the backend for a clean slate.
 
-Дополнительный сценарий презентации размещён в `docs/android/demo_script.md`.
+When the ML pipeline is reattached, the `/model/detect` endpoint will return real gestures; until then it provides a deterministic placeholder response.
+
+## VS Code tips
+
+See the root `README.md` for VS Code automation, including tasks for `./gradlew assembleDebug` and device debugging.
+

--- a/android/src/main/assets/config/backend.json
+++ b/android/src/main/assets/config/backend.json
@@ -1,6 +1,5 @@
 {
-  "backendBaseUrl": "http://10.0.2.2:8000",
+  "backendBaseUrl": "http://10.0.2.2:8080",
   "detectionEndpoint": "/model/detect",
   "timeoutSeconds": 15
 }
-


### PR DESCRIPTION
## Summary
- rewrite the top-level README to describe the Spring Boot backend, Android client status, API surface, and VS Code workflow
- refresh the Android documentation to reference the Java backend and updated configuration file
- point the Android client configuration at the Spring Boot service and explain the current inference placeholder

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_69035264e054833395a859047ca8dc88