### PR TITLE
Add comprehensive unit tests for backend services

### DIFF
--- a/java-backend/src/test/java/com/zazeks/AdminServiceTest.java
+++ b/java-backend/src/test/java/com/zazeks/AdminServiceTest.java
@@ -1,0 +1,44 @@
+package com.zazeks;
+
+import com.zazeks.api.AdminService;
+import com.zazeks.database.models.Game;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class AdminServiceTest extends ServiceTestHarness {
+
+    @Test
+    void addAdminRejectsDuplicates() {
+        int userId = authService.register("admin_user", "pass_123", null).userId();
+        AdminService admin = adminService;
+        admin.addAdmin(userId);
+        assertThrows(IllegalStateException.class, () -> admin.addAdmin(userId));
+    }
+
+    @Test
+    void deleteUserFailsWhileAdmin() {
+        int userId = authService.register("protected", "pass_123", null).userId();
+        adminService.addAdmin(userId);
+        assertThrows(IllegalStateException.class, () -> adminService.deleteUser(userId));
+    }
+
+    @Test
+    void changeUsernameRequiresUniqueness() {
+        int userId = authService.register("rename_me", "pass_123", null).userId();
+        authService.register("taken_name", "pass_123", null);
+        assertThrows(IllegalStateException.class, () -> adminService.changeUsername(userId, "taken_name"));
+    }
+
+    @Test
+    void deleteGameRemovesRecords() {
+        int userId = authService.register("player_admin", "pass_123", null).userId();
+        Game game = new Game(null, userId, "rock", "scissors", "win", Instant.now());
+        database.saveGame(game);
+        int gameId = game.getId();
+        adminService.deleteGame(gameId);
+        assertTrue(database.findGameById(gameId).isEmpty());
+    }
+}

--- a/java-backend/src/test/java/com/zazeks/AuthServiceTest.java
+++ b/java-backend/src/test/java/com/zazeks/AuthServiceTest.java
@@ -1,0 +1,41 @@
+package com.zazeks;
+
+import com.zazeks.api.AuthService;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class AuthServiceTest extends ServiceTestHarness {
+
+    @Test
+    void registrationRejectsInvalidUsernames() {
+        assertThrows(IllegalArgumentException.class, () -> authService.register("abc", "valid_1", null));
+        assertThrows(IllegalArgumentException.class, () -> authService.register("invalid!", "valid_1", null));
+    }
+
+    @Test
+    void registrationRejectsInvalidPasswords() {
+        assertThrows(IllegalArgumentException.class, () -> authService.register("valid_1", "bad", null));
+        assertThrows(IllegalArgumentException.class, () -> authService.register("valid_1", "with-hyphen", null));
+    }
+
+    @Test
+    void registrationRejectsDuplicateUsernamesIgnoringCase() {
+        AuthService.RegistrationResult registration = authService.register("PlayerOne", "Pass_123", null);
+        assertNotNull(registration);
+        assertThrows(IllegalStateException.class, () -> authService.register("playerone", "Pass_123", null));
+    }
+
+    @Test
+    void loginFailsForUnknownUser() {
+        assertThrows(IllegalArgumentException.class, () -> authService.login("ghost", "pass"));
+    }
+
+    @Test
+    void loginReturnsJwtContainingSubject() {
+        int userId = authService.register("player1", "pass_123", null).userId();
+        AuthService.LoginResult login = authService.login("player1", "pass_123");
+        assertEquals("bearer", login.tokenType());
+        assertEquals(userId, tokenService.extractUserId(login.accessToken()));
+    }
+}

--- a/java-backend/src/test/java/com/zazeks/GameServiceTest.java
+++ b/java-backend/src/test/java/com/zazeks/GameServiceTest.java
@@ -1,0 +1,35 @@
+package com.zazeks;
+
+import com.zazeks.database.models.Game;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class GameServiceTest extends ServiceTestHarness {
+
+    @Test
+    void createGamePreventsDuplicatesWithinThreshold() {
+        int userId = authService.register("dupes", "pass_123", null).userId();
+        gameService.createGame(userId, "rock", "scissors", "win");
+        IllegalStateException ex = assertThrows(IllegalStateException.class, () ->
+                gameService.createGame(userId, "rock", "scissors", "win"));
+        assertTrue(ex.getMessage().contains("Duplicate"));
+    }
+
+    @Test
+    void createGameAllowsNewSubmissionAfterThreshold() {
+        int userId = authService.register("threshold", "pass_123", null).userId();
+        Game oldGame = new Game(null, userId, "rock", "scissors", "win", Instant.now().minusSeconds(60));
+        database.saveGame(oldGame);
+        assertDoesNotThrow(() -> gameService.createGame(userId, "rock", "scissors", "win"));
+    }
+
+    @Test
+    void getGamesRequiresOwnership() {
+        int userId = authService.register("owner", "pass_123", null).userId();
+        int otherId = authService.register("other", "pass_123", null).userId();
+        assertThrows(SecurityException.class, () -> gameService.getGamesForUser(userId, otherId));
+    }
+}

--- a/java-backend/src/test/java/com/zazeks/InferenceServiceTest.java
+++ b/java-backend/src/test/java/com/zazeks/InferenceServiceTest.java
@@ -1,0 +1,80 @@
+package com.zazeks;
+
+import com.zazeks.api.InferenceService;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class InferenceServiceTest extends ServiceTestHarness {
+
+    @Test
+    void detectGesturePersistsMetadataAndReturnsResult() throws IOException {
+        byte[] payload = new byte[] {1, 2, 3, 4, 5};
+        MockMultipartFile file = new MockMultipartFile("file", "frame.jpg", "image/jpeg", payload);
+
+        InferenceService.DetectionResult result = inferenceService.detectGesture(file, null);
+
+        assertNotNull(result);
+        assertNotNull(result.detectedAt());
+        assertTrue(result.detectionId() > 0);
+        assertTrue(result.durationMillis() >= 0);
+        assertEquals(1, database.findAllDetectionMetadata().size());
+    }
+
+    @Test
+    void detectGestureRejectsEmptyFile() {
+        MockMultipartFile file = new MockMultipartFile("file", new byte[0]);
+        assertThrows(IllegalArgumentException.class, () -> inferenceService.detectGesture(file, null));
+    }
+
+    @Test
+    void detectGestureWrapsIoExceptions() {
+        MultipartFile failingFile = new MultipartFile() {
+            @Override
+            public String getName() {
+                return "fail";
+            }
+
+            @Override
+            public String getOriginalFilename() {
+                return "fail.bin";
+            }
+
+            @Override
+            public String getContentType() {
+                return "application/octet-stream";
+            }
+
+            @Override
+            public boolean isEmpty() {
+                return false;
+            }
+
+            @Override
+            public long getSize() {
+                return 10;
+            }
+
+            @Override
+            public byte[] getBytes() throws IOException {
+                throw new IOException("boom");
+            }
+
+            @Override
+            public java.io.InputStream getInputStream() throws IOException {
+                throw new IOException("boom");
+            }
+
+            @Override
+            public void transferTo(java.io.File dest) throws IOException {
+                throw new IOException("boom");
+            }
+        };
+
+        assertThrows(IllegalArgumentException.class, () -> inferenceService.detectGesture(failingFile, 1));
+    }
+}

--- a/java-backend/src/test/java/com/zazeks/MultiplayerServiceTest.java
+++ b/java-backend/src/test/java/com/zazeks/MultiplayerServiceTest.java
@@ -1,0 +1,97 @@
+package com.zazeks;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zazeks.support.StubWebSocketSession;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.socket.CloseStatus;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class MultiplayerServiceTest extends ServiceTestHarness {
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    void playersMatchFromQueueAndCreateSession() throws IOException {
+        int userA = authService.register("queue_a", "pass_123", null).userId();
+        int userB = authService.register("queue_b", "pass_123", null).userId();
+        StubWebSocketSession sessionA = new StubWebSocketSession();
+        StubWebSocketSession sessionB = new StubWebSocketSession();
+
+        sendJoin(sessionA, userA);
+        sendJoin(sessionB, userB);
+
+        assertEquals(2, sessionA.getSentMessages().size());
+        assertEquals(2, sessionB.getSentMessages().size());
+
+        JsonNode matchMessage = mapper.readTree(sessionA.getLastMessage().getPayload());
+        assertEquals("match_found", matchMessage.get("action").asText());
+        assertEquals(1, database.findAllMultiplayerSessions().size());
+    }
+
+    @Test
+    void gesturesResolveBattleAndUpdateOnlineStats() throws Exception {
+        int userA = authService.register("battle_a", "pass_123", null).userId();
+        int userB = authService.register("battle_b", "pass_123", null).userId();
+        StubWebSocketSession sessionA = new StubWebSocketSession();
+        StubWebSocketSession sessionB = new StubWebSocketSession();
+
+        sendJoin(sessionA, userA);
+        sendJoin(sessionB, userB);
+
+        sendReady(sessionA);
+        sendReady(sessionB);
+
+        sendGesture(sessionA, "rock");
+        sendGesture(sessionB, "scissors");
+
+        Object match = extractActiveMatch();
+        Method conclude = multiplayerService.getClass().getDeclaredMethod("concludeBattle", match.getClass());
+        conclude.setAccessible(true);
+        conclude.invoke(multiplayerService, match);
+
+        JsonNode last = mapper.readTree(sessionA.getLastMessage().getPayload());
+        assertEquals("battle_end", last.get("action").asText());
+        assertEquals("battle_a", last.get("winner").asText());
+
+        assertEquals(1, database.findUserById(userA).orElseThrow().getOnlineWins());
+        assertEquals(1, database.findUserById(userA).orElseThrow().getOnlineGames());
+        assertEquals(0, database.findUserById(userB).orElseThrow().getOnlineWins());
+        assertEquals(1, database.findUserById(userB).orElseThrow().getOnlineGames());
+
+        multiplayerService.handleDisconnect(sessionA, CloseStatus.NORMAL);
+    }
+
+    private void sendJoin(StubWebSocketSession session, int userId) throws IOException {
+        multiplayerService.handleMessage(session, mapper.writeValueAsString(Map.of(
+                "action", "join",
+                "user_id", userId
+        )));
+    }
+
+    private void sendReady(StubWebSocketSession session) throws IOException {
+        multiplayerService.handleMessage(session, mapper.writeValueAsString(Map.of(
+                "action", "ready"
+        )));
+    }
+
+    private void sendGesture(StubWebSocketSession session, String gesture) throws IOException {
+        multiplayerService.handleMessage(session, mapper.writeValueAsString(Map.of(
+                "action", "gesture",
+                "gesture", gesture
+        )));
+    }
+
+    private Object extractActiveMatch() throws Exception {
+        Field field = multiplayerService.getClass().getDeclaredField("activeMatches");
+        field.setAccessible(true);
+        Map<?, ?> matches = (Map<?, ?>) field.get(multiplayerService);
+        assertFalse(matches.isEmpty(), "Expected an active match");
+        return matches.values().iterator().next();
+    }
+}

--- a/java-backend/src/test/java/com/zazeks/ServiceTestHarness.java
+++ b/java-backend/src/test/java/com/zazeks/ServiceTestHarness.java
@@ -1,0 +1,48 @@
+package com.zazeks;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zazeks.api.AdminService;
+import com.zazeks.api.AuthService;
+import com.zazeks.api.GameService;
+import com.zazeks.api.InferenceService;
+import com.zazeks.api.MultiplayerService;
+import com.zazeks.api.UserService;
+import com.zazeks.database.InMemoryDatabase;
+import com.zazeks.security.PasswordService;
+import com.zazeks.security.TokenService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+
+/**
+ * Shared fixture for service-layer unit tests.
+ */
+public abstract class ServiceTestHarness {
+    protected InMemoryDatabase database;
+    protected PasswordService passwordService;
+    protected TokenService tokenService;
+    protected AuthService authService;
+    protected GameService gameService;
+    protected UserService userService;
+    protected MultiplayerService multiplayerService;
+    protected AdminService adminService;
+    protected InferenceService inferenceService;
+
+    @BeforeEach
+    void setUpHarness() {
+        database = new InMemoryDatabase();
+        passwordService = new PasswordService();
+        tokenService = new TokenService();
+        authService = new AuthService(database, passwordService, tokenService);
+        gameService = new GameService(database);
+        userService = new UserService(database);
+        multiplayerService = new MultiplayerService(database, new ObjectMapper());
+        adminService = new AdminService(database);
+        inferenceService = new InferenceService(database);
+    }
+
+    @AfterEach
+    void tearDownHarness() {
+        multiplayerService.shutdown();
+        database.reset();
+    }
+}

--- a/java-backend/src/test/java/com/zazeks/UserServiceTest.java
+++ b/java-backend/src/test/java/com/zazeks/UserServiceTest.java
@@ -1,0 +1,67 @@
+package com.zazeks;
+
+import com.zazeks.api.UserService;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class UserServiceTest extends ServiceTestHarness {
+
+    @Test
+    void profileUpdateRequiresOwnership() {
+        int ownerId = authService.register("owner_1", "pass_123", null).userId();
+        int attackerId = authService.register("attacker", "pass_123", null).userId();
+        assertThrows(SecurityException.class, () -> userService.updateUserProfile(ownerId, attackerId, "new_name", null));
+    }
+
+    @Test
+    void updateRejectsDuplicateUsername() {
+        int userId = authService.register("first_user", "pass_123", null).userId();
+        authService.register("other_user", "pass_123", null);
+        assertThrows(IllegalStateException.class, () -> userService.updateUserProfile(userId, userId, "other_user", null));
+    }
+
+    @Test
+    void updateRejectsInvalidImagePayload() {
+        int userId = authService.register("image_user", "pass_123", null).userId();
+        String invalid = "not-base64";
+        assertThrows(IllegalArgumentException.class, () -> userService.updateUserProfile(userId, userId, null, invalid));
+    }
+
+    @Test
+    void updateAppliesChangesWhenValid() {
+        int userId = authService.register("profile_user", "pass_123", null).userId();
+        String photo = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGP4z8DwHwAFAAH/iZk9HQA" +
+                "AAABJRU5ErkJggg==";
+        UserService.UpdateResult result = userService.updateUserProfile(userId, userId, "profile_user2", photo);
+        assertEquals("profile_user2", result.user().username());
+        assertEquals(photo, result.user().photo());
+    }
+
+    @Test
+    void leaderboardOrdersByOfflineAndOnlineWins() {
+        int alice = authService.register("alice_1", "pass_123", null).userId();
+        int bob = authService.register("bob_2", "pass_123", null).userId();
+        int carol = authService.register("carol_3", "pass_123", null).userId();
+
+        gameService.createGame(alice, "rock", "scissors", "win");
+        gameService.createGame(alice, "paper", "rock", "win");
+        gameService.createGame(bob, "rock", "scissors", "win");
+
+        database.findUserById(carol).ifPresent(user -> {
+            user.incrementOnlineWins();
+            user.incrementOnlineGames();
+            user.incrementOnlineWins();
+            user.incrementOnlineGames();
+            database.saveUser(user);
+        });
+
+        var offline = userService.getOfflineLeaderboard();
+        assertEquals("alice_1", offline.get(0).username());
+        assertEquals("bob_2", offline.get(1).username());
+
+        var online = userService.getOnlineLeaderboard();
+        assertEquals("carol_3", online.get(0).username());
+        assertEquals(2, online.get(0).onlineWins());
+    }
+}

--- a/java-backend/src/test/java/com/zazeks/support/StubWebSocketSession.java
+++ b/java-backend/src/test/java/com/zazeks/support/StubWebSocketSession.java
@@ -1,0 +1,126 @@
+package com.zazeks.support;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.lang.Nullable;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketExtension;
+import org.springframework.web.socket.WebSocketMessage;
+import org.springframework.web.socket.WebSocketSession;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.security.Principal;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class StubWebSocketSession implements WebSocketSession {
+    private final String id = UUID.randomUUID().toString();
+    private final List<TextMessage> messages = Collections.synchronizedList(new ArrayList<>());
+    private final Map<String, Object> attributes = new ConcurrentHashMap<>();
+    private volatile boolean open = true;
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public URI getUri() {
+        return URI.create("ws://localhost/mock");
+    }
+
+    @Override
+    public HttpHeaders getHandshakeHeaders() {
+        return HttpHeaders.EMPTY;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    @Override
+    public Principal getPrincipal() {
+        return null;
+    }
+
+    @Override
+    public InetSocketAddress getLocalAddress() {
+        return null;
+    }
+
+    @Override
+    public InetSocketAddress getRemoteAddress() {
+        return null;
+    }
+
+    @Override
+    public String getAcceptedProtocol() {
+        return null;
+    }
+
+    @Override
+    public void setTextMessageSizeLimit(int messageSizeLimit) {
+    }
+
+    @Override
+    public int getTextMessageSizeLimit() {
+        return 8192;
+    }
+
+    @Override
+    public void setBinaryMessageSizeLimit(int messageSizeLimit) {
+    }
+
+    @Override
+    public int getBinaryMessageSizeLimit() {
+        return 8192;
+    }
+
+    @Override
+    public List<WebSocketExtension> getExtensions() {
+        return List.of();
+    }
+
+    @Override
+    public void sendMessage(WebSocketMessage<?> message) throws IOException {
+        if (!open) {
+            throw new IOException("Session closed");
+        }
+        if (message instanceof TextMessage text) {
+            messages.add(text);
+        }
+    }
+
+    @Override
+    public boolean isOpen() {
+        return open;
+    }
+
+    @Override
+    public void close() throws IOException {
+        close(CloseStatus.NORMAL);
+    }
+
+    @Override
+    public void close(CloseStatus status) {
+        this.open = false;
+    }
+
+    public List<TextMessage> getSentMessages() {
+        return messages;
+    }
+
+    @Nullable
+    public TextMessage getLastMessage() {
+        synchronized (messages) {
+            return messages.isEmpty() ? null : messages.get(messages.size() - 1);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a reusable JUnit 5 harness that wires in-memory fixtures for service-layer testing
- cover authentication, profile updates, duplicate-game protection, leaderboards, admin flows, multiplayer logic, and inference edge cases
- introduce a stub WebSocket session for fast multiplayer unit tests

## Testing
- ./gradlew test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_690369eadc0c833394276587e0b86a43