### PR TITLE
Fix GridLayout namespace usage

### DIFF
--- a/android/src/main/res/layout/fragment_game.xml
+++ b/android/src/main/res/layout/fragment_game.xml
@@ -107,9 +107,9 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="16dp"
-                android:alignmentMode="alignMargins"
-                android:columnCount="3"
-                android:useDefaultMargins="true" />
+                app:alignmentMode="alignMargins"
+                app:columnCount="3"
+                app:useDefaultMargins="true" />
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/quitButton"

--- a/android/src/main/res/layout/fragment_results.xml
+++ b/android/src/main/res/layout/fragment_results.xml
@@ -55,9 +55,9 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="16dp"
-                android:alignmentMode="alignMargins"
-                android:columnCount="3"
-                android:useDefaultMargins="true" />
+                app:alignmentMode="alignMargins"
+                app:columnCount="3"
+                app:useDefaultMargins="true" />
         </LinearLayout>
     </androidx.cardview.widget.CardView>
 


### PR DESCRIPTION
## Summary
- use app namespace for GridLayout attributes in the game and results fragments to comply with AndroidX requirements

## Testing
- ⚠️ ./gradlew lintVitalRelease (fails: gradlew not marked executable in repository)


------
https://chatgpt.com/codex/tasks/task_e_6904727836f0833397c4278389bb849d