### PR TITLE
Add authentication flow with secure token handling

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -124,6 +124,9 @@ dependencies {
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3'
 
     implementation 'com.squareup.okhttp3:okhttp:4.11.0'
+    implementation 'com.squareup.retrofit2:retrofit:2.9.0'
+    implementation 'com.squareup.retrofit2:converter-gson:2.9.0'
+    implementation 'androidx.datastore:datastore-preferences:1.0.0'
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'com.squareup.okhttp3:mockwebserver:4.11.0'

--- a/android/src/main/java/com/example/zazeks/data/auth/AuthApi.kt
+++ b/android/src/main/java/com/example/zazeks/data/auth/AuthApi.kt
@@ -1,0 +1,13 @@
+package com.example.zazeks.data.auth
+
+import retrofit2.http.Body
+import retrofit2.http.POST
+
+interface AuthApi {
+
+    @POST("auth/register")
+    suspend fun register(@Body request: RegisterRequest): RegistrationResponse
+
+    @POST("auth/login")
+    suspend fun login(@Body request: LoginRequest): LoginResultDto
+}

--- a/android/src/main/java/com/example/zazeks/data/auth/AuthDtos.kt
+++ b/android/src/main/java/com/example/zazeks/data/auth/AuthDtos.kt
@@ -1,0 +1,24 @@
+package com.example.zazeks.data.auth
+
+import com.google.gson.annotations.SerializedName
+
+data class RegisterRequest(
+    val username: String,
+    val password: String,
+)
+
+data class RegistrationResponse(
+    @SerializedName("userId") val userId: Int,
+    val message: String,
+)
+
+data class LoginRequest(
+    val username: String,
+    val password: String,
+)
+
+data class LoginResultDto(
+    @SerializedName("accessToken") val accessToken: String,
+    @SerializedName("tokenType") val tokenType: String,
+    @SerializedName("userId") val userId: Int,
+)

--- a/android/src/main/java/com/example/zazeks/data/auth/AuthRepository.kt
+++ b/android/src/main/java/com/example/zazeks/data/auth/AuthRepository.kt
@@ -1,0 +1,63 @@
+package com.example.zazeks.data.auth
+
+import com.example.zazeks.domain.auth.LoginResult
+import com.example.zazeks.domain.auth.RegistrationResult
+import com.example.zazeks.infra.auth.AuthSession
+import com.example.zazeks.infra.auth.AuthTokenStorage
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import retrofit2.HttpException
+import java.io.IOException
+
+@Singleton
+class AuthRepository @Inject constructor(
+    private val api: AuthApi,
+    private val tokenStorage: AuthTokenStorage,
+) {
+
+    val isAuthenticated: Flow<Boolean> = tokenStorage.session.map { session -> session != null }
+
+    suspend fun register(username: String, password: String): Result<RegistrationResult> =
+        runCatching {
+            api.register(RegisterRequest(username, password)).toDomain()
+        }.mapError("Не удалось зарегистрироваться")
+
+    suspend fun login(username: String, password: String): Result<LoginResult> =
+        runCatching {
+            val result = api.login(LoginRequest(username, password))
+            val session = AuthSession(result.accessToken, result.tokenType, result.userId)
+            tokenStorage.persist(session)
+            result.toDomain()
+        }.mapError("Не удалось выполнить вход")
+
+    suspend fun logout() {
+        tokenStorage.clear()
+    }
+
+    private fun RegistrationResponse.toDomain() = RegistrationResult(userId = userId, message = message)
+
+    private fun LoginResultDto.toDomain() = LoginResult(
+        accessToken = accessToken,
+        tokenType = tokenType,
+        userId = userId,
+    )
+
+    private fun <T> Result<T>.mapError(defaultMessage: String): Result<T> = fold(
+        onSuccess = { Result.success(it) },
+        onFailure = { throwable -> Result.failure(mapException(throwable, defaultMessage)) },
+    )
+
+    private fun mapException(throwable: Throwable, defaultMessage: String): Exception = when (throwable) {
+        is HttpException -> {
+            val errorBody = throwable.response()?.errorBody()?.string().orEmpty()
+            val message = errorBody.takeIf { it.isNotBlank() } ?: defaultMessage
+            AuthRepositoryException(message, throwable)
+        }
+        is IOException -> AuthRepositoryException("Проверьте подключение к сети", throwable)
+        else -> AuthRepositoryException(throwable.message ?: defaultMessage, throwable)
+    }
+}
+
+class AuthRepositoryException(message: String, cause: Throwable? = null) : Exception(message, cause)

--- a/android/src/main/java/com/example/zazeks/di/DataStoreModule.kt
+++ b/android/src/main/java/com/example/zazeks/di/DataStoreModule.kt
@@ -1,0 +1,24 @@
+package com.example.zazeks.di
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStore
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+private val Context.authDataStore by preferencesDataStore(name = "auth")
+
+@Module
+@InstallIn(SingletonComponent::class)
+object DataStoreModule {
+
+    @Provides
+    @Singleton
+    fun provideAuthDataStore(@ApplicationContext context: Context): DataStore<Preferences> =
+        context.authDataStore
+}

--- a/android/src/main/java/com/example/zazeks/di/NetworkModule.kt
+++ b/android/src/main/java/com/example/zazeks/di/NetworkModule.kt
@@ -1,11 +1,16 @@
 package com.example.zazeks.di
 
+import com.example.zazeks.data.auth.AuthApi
+import com.example.zazeks.infra.auth.AuthInterceptor
+import com.example.zazeks.infra.config.BackendConfig
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import javax.inject.Singleton
 import okhttp3.OkHttpClient
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -13,7 +18,21 @@ object NetworkModule {
 
     @Provides
     @Singleton
-    fun provideOkHttpClient(): OkHttpClient = OkHttpClient.Builder()
+    fun provideOkHttpClient(authInterceptor: AuthInterceptor): OkHttpClient = OkHttpClient.Builder()
         .retryOnConnectionFailure(true)
+        .addInterceptor(authInterceptor)
         .build()
+
+    @Provides
+    @Singleton
+    fun provideRetrofit(backendConfig: BackendConfig, okHttpClient: OkHttpClient): Retrofit =
+        Retrofit.Builder()
+            .baseUrl(backendConfig.baseUrl)
+            .client(okHttpClient)
+            .addConverterFactory(GsonConverterFactory.create())
+            .build()
+
+    @Provides
+    @Singleton
+    fun provideAuthApi(retrofit: Retrofit): AuthApi = retrofit.create(AuthApi::class.java)
 }

--- a/android/src/main/java/com/example/zazeks/domain/auth/LoginResult.kt
+++ b/android/src/main/java/com/example/zazeks/domain/auth/LoginResult.kt
@@ -1,0 +1,7 @@
+package com.example.zazeks.domain.auth
+
+data class LoginResult(
+    val accessToken: String,
+    val tokenType: String,
+    val userId: Int,
+)

--- a/android/src/main/java/com/example/zazeks/domain/auth/RegistrationResult.kt
+++ b/android/src/main/java/com/example/zazeks/domain/auth/RegistrationResult.kt
@@ -1,0 +1,6 @@
+package com.example.zazeks.domain.auth
+
+data class RegistrationResult(
+    val userId: Int,
+    val message: String,
+)

--- a/android/src/main/java/com/example/zazeks/infra/auth/AuthInterceptor.kt
+++ b/android/src/main/java/com/example/zazeks/infra/auth/AuthInterceptor.kt
@@ -1,0 +1,44 @@
+package com.example.zazeks.infra.auth
+
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.runBlocking
+import okhttp3.Interceptor
+import okhttp3.Response
+
+@Singleton
+class AuthInterceptor @Inject constructor(
+    private val tokenStorage: AuthTokenStorage,
+) : Interceptor {
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val request = chain.request()
+        if (request.header(AUTHORIZATION_HEADER) != null) {
+            return chain.proceed(request)
+        }
+        val path = request.url.encodedPath
+        if (path.endsWith("/auth/login") || path.endsWith("/auth/register")) {
+            return chain.proceed(request)
+        }
+        val session = runBlocking { tokenStorage.currentSession() }
+        val token = session?.accessToken
+        if (token.isNullOrBlank()) {
+            return chain.proceed(request)
+        }
+        val tokenType = session.tokenType.ifBlank { DEFAULT_TOKEN_TYPE }
+        val headerValue = "${tokenType.capitalizeFirst()} $token"
+        val authenticatedRequest = request.newBuilder()
+            .addHeader(AUTHORIZATION_HEADER, headerValue)
+            .build()
+        return chain.proceed(authenticatedRequest)
+    }
+
+    private fun String.capitalizeFirst(): String = replaceFirstChar { char ->
+        if (char.isLowerCase()) char.titlecase() else char.toString()
+    }
+
+    companion object {
+        private const val AUTHORIZATION_HEADER = "Authorization"
+        private const val DEFAULT_TOKEN_TYPE = "Bearer"
+    }
+}

--- a/android/src/main/java/com/example/zazeks/infra/auth/AuthTokenStorage.kt
+++ b/android/src/main/java/com/example/zazeks/infra/auth/AuthTokenStorage.kt
@@ -1,0 +1,62 @@
+package com.example.zazeks.infra.auth
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.map
+
+@Singleton
+class AuthTokenStorage @Inject constructor(
+    private val dataStore: DataStore<Preferences>,
+) {
+
+    val session: Flow<AuthSession?> = dataStore.data.map { preferences ->
+        val token = preferences[ACCESS_TOKEN_KEY]
+        if (token.isNullOrBlank()) {
+            null
+        } else {
+            AuthSession(
+                accessToken = token,
+                tokenType = preferences[TOKEN_TYPE_KEY].orEmpty(),
+                userId = preferences[USER_ID_KEY]
+            )
+        }
+    }
+
+    suspend fun persist(session: AuthSession) {
+        dataStore.edit { preferences ->
+            preferences[ACCESS_TOKEN_KEY] = session.accessToken
+            preferences[TOKEN_TYPE_KEY] = session.tokenType.ifBlank { DEFAULT_TOKEN_TYPE }
+            session.userId?.let { preferences[USER_ID_KEY] = it } ?: preferences.remove(USER_ID_KEY)
+        }
+    }
+
+    suspend fun clear() {
+        dataStore.edit { preferences ->
+            preferences.remove(ACCESS_TOKEN_KEY)
+            preferences.remove(TOKEN_TYPE_KEY)
+            preferences.remove(USER_ID_KEY)
+        }
+    }
+
+    suspend fun currentSession(): AuthSession? = session.firstOrNull()
+
+    companion object {
+        private val ACCESS_TOKEN_KEY = stringPreferencesKey("access_token")
+        private val TOKEN_TYPE_KEY = stringPreferencesKey("token_type")
+        private val USER_ID_KEY = intPreferencesKey("user_id")
+        private const val DEFAULT_TOKEN_TYPE = "Bearer"
+    }
+}
+
+data class AuthSession(
+    val accessToken: String,
+    val tokenType: String,
+    val userId: Int?,
+)

--- a/android/src/main/java/com/example/zazeks/ui/auth/AuthFragment.kt
+++ b/android/src/main/java/com/example/zazeks/ui/auth/AuthFragment.kt
@@ -1,0 +1,153 @@
+package com.example.zazeks.ui.auth
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.view.isVisible
+import androidx.core.widget.doAfterTextChanged
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import androidx.navigation.NavOptions
+import androidx.navigation.fragment.findNavController
+import com.example.zazeks.R
+import com.example.zazeks.databinding.FragmentAuthBinding
+import com.google.android.material.snackbar.Snackbar
+import com.google.android.material.tabs.TabLayout
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
+
+@AndroidEntryPoint
+class AuthFragment : Fragment() {
+
+    private var _binding: FragmentAuthBinding? = null
+    private val binding get() = _binding!!
+
+    private val viewModel: AuthViewModel by viewModels()
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        _binding = FragmentAuthBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setupListeners()
+        observeState()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+    private fun setupListeners() {
+        binding.authTabs.addOnTabSelectedListener(object : TabLayout.OnTabSelectedListener {
+            override fun onTabSelected(tab: TabLayout.Tab) {
+                val selectedTab = if (tab.position == 0) AuthTab.LOGIN else AuthTab.REGISTER
+                viewModel.selectTab(selectedTab)
+            }
+
+            override fun onTabUnselected(tab: TabLayout.Tab) = Unit
+            override fun onTabReselected(tab: TabLayout.Tab) = Unit
+        })
+
+        binding.loginSubmitButton.setOnClickListener {
+            viewModel.submitLogin(
+                username = binding.loginUsernameInput.text?.toString().orEmpty(),
+                password = binding.loginPasswordInput.text?.toString().orEmpty(),
+            )
+        }
+        binding.registerSubmitButton.setOnClickListener {
+            viewModel.submitRegistration(
+                username = binding.registerUsernameInput.text?.toString().orEmpty(),
+                password = binding.registerPasswordInput.text?.toString().orEmpty(),
+                confirmation = binding.registerConfirmInput.text?.toString().orEmpty(),
+            )
+        }
+
+        binding.loginUsernameInput.doAfterTextChanged {
+            binding.loginUsernameInputLayout.error = null
+            binding.errorText.isVisible = false
+            viewModel.consumeError()
+        }
+        binding.loginPasswordInput.doAfterTextChanged {
+            binding.loginPasswordInputLayout.error = null
+            binding.errorText.isVisible = false
+            viewModel.consumeError()
+        }
+        binding.registerUsernameInput.doAfterTextChanged {
+            binding.registerUsernameInputLayout.error = null
+            binding.errorText.isVisible = false
+            viewModel.consumeError()
+        }
+        binding.registerPasswordInput.doAfterTextChanged {
+            binding.registerPasswordInputLayout.error = null
+            binding.errorText.isVisible = false
+            viewModel.consumeError()
+        }
+        binding.registerConfirmInput.doAfterTextChanged {
+            binding.registerConfirmInputLayout.error = null
+            binding.errorText.isVisible = false
+            viewModel.consumeError()
+        }
+    }
+
+    private fun observeState() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                launch {
+                    viewModel.state.collect { state -> renderState(state) }
+                }
+                launch {
+                    viewModel.events.collect { event -> handleEvent(event) }
+                }
+            }
+        }
+    }
+
+    private fun renderState(state: AuthViewState) {
+        val selectedIndex = if (state.selectedTab == AuthTab.LOGIN) 0 else 1
+        if (binding.authTabs.selectedTabPosition != selectedIndex) {
+            binding.authTabs.getTabAt(selectedIndex)?.select()
+        }
+        binding.loginForm.isVisible = state.selectedTab == AuthTab.LOGIN
+        binding.registerForm.isVisible = state.selectedTab == AuthTab.REGISTER
+
+        binding.loginUsernameInputLayout.error = if (state.selectedTab == AuthTab.LOGIN) state.usernameError else null
+        binding.loginPasswordInputLayout.error = if (state.selectedTab == AuthTab.LOGIN) state.passwordError else null
+
+        binding.registerUsernameInputLayout.error = if (state.selectedTab == AuthTab.REGISTER) state.usernameError else null
+        binding.registerPasswordInputLayout.error = if (state.selectedTab == AuthTab.REGISTER) state.passwordError else null
+        binding.registerConfirmInputLayout.error = if (state.selectedTab == AuthTab.REGISTER) state.confirmPasswordError else null
+
+        val hasError = !state.generalError.isNullOrBlank()
+        binding.errorText.isVisible = hasError
+        binding.errorText.text = state.generalError ?: ""
+
+        binding.loadingIndicator.isVisible = state.isLoading
+        binding.loginSubmitButton.isEnabled = !state.isLoading
+        binding.registerSubmitButton.isEnabled = !state.isLoading
+    }
+
+    private fun handleEvent(event: AuthEvent) {
+        when (event) {
+            AuthEvent.NavigateToMain -> navigateToMainMenu()
+            is AuthEvent.ShowMessage -> Snackbar.make(binding.root, event.message, Snackbar.LENGTH_LONG).show()
+        }
+    }
+
+    private fun navigateToMainMenu() {
+        val navOptions = NavOptions.Builder()
+            .setPopUpTo(R.id.authFragment, true)
+            .build()
+        findNavController().navigate(R.id.action_authFragment_to_mainMenuFragment, null, navOptions)
+    }
+}

--- a/android/src/main/java/com/example/zazeks/ui/auth/AuthViewModel.kt
+++ b/android/src/main/java/com/example/zazeks/ui/auth/AuthViewModel.kt
@@ -1,0 +1,187 @@
+package com.example.zazeks.ui.auth
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.zazeks.data.auth.AuthRepository
+import com.example.zazeks.data.auth.AuthRepositoryException
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+@HiltViewModel
+class AuthViewModel @Inject constructor(
+    private val authRepository: AuthRepository,
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(AuthViewState())
+    val state: StateFlow<AuthViewState> = _state.asStateFlow()
+
+    private val eventsChannel = Channel<AuthEvent>(Channel.BUFFERED)
+    val events = eventsChannel.receiveAsFlow()
+
+    private var hasNavigated = false
+
+    init {
+        observeAuthState()
+    }
+
+    fun selectTab(tab: AuthTab) {
+        _state.update {
+            it.copy(
+                selectedTab = tab,
+                usernameError = null,
+                passwordError = null,
+                confirmPasswordError = null,
+                generalError = null,
+            )
+        }
+    }
+
+    fun submitLogin(username: String, password: String) {
+        val trimmedUsername = username.trim()
+        val usernameError = validateUsername(trimmedUsername)
+        val passwordError = validatePassword(password)
+        if (usernameError != null || passwordError != null) {
+            _state.update {
+                it.copy(
+                    usernameError = usernameError,
+                    passwordError = passwordError,
+                    generalError = null,
+                )
+            }
+            return
+        }
+        _state.update {
+            it.copy(
+                isLoading = true,
+                usernameError = null,
+                passwordError = null,
+                generalError = null,
+            )
+        }
+        viewModelScope.launch {
+            val result = authRepository.login(trimmedUsername, password)
+            result.fold(
+                onSuccess = {
+                    _state.update { current -> current.copy(isLoading = false) }
+                },
+                onFailure = { throwable ->
+                    _state.update {
+                        it.copy(
+                            isLoading = false,
+                            generalError = resolveMessage(throwable, "Не удалось выполнить вход"),
+                        )
+                    }
+                },
+            )
+        }
+    }
+
+    fun submitRegistration(username: String, password: String, confirmation: String) {
+        val trimmedUsername = username.trim()
+        val usernameError = validateUsername(trimmedUsername)
+        val passwordError = validatePassword(password)
+        val confirmationError = if (password == confirmation) null else "Пароли не совпадают"
+        if (usernameError != null || passwordError != null || confirmationError != null) {
+            _state.update {
+                it.copy(
+                    usernameError = usernameError,
+                    passwordError = passwordError,
+                    confirmPasswordError = confirmationError,
+                    generalError = null,
+                )
+            }
+            return
+        }
+        _state.update {
+            it.copy(
+                isLoading = true,
+                usernameError = null,
+                passwordError = null,
+                confirmPasswordError = null,
+                generalError = null,
+            )
+        }
+        viewModelScope.launch {
+            val result = authRepository.register(trimmedUsername, password)
+            result.fold(
+                onSuccess = { registration ->
+                    _state.update { current -> current.copy(isLoading = false) }
+                    selectTab(AuthTab.LOGIN)
+                    eventsChannel.trySend(AuthEvent.ShowMessage(registration.message))
+                },
+                onFailure = { throwable ->
+                    _state.update {
+                        it.copy(
+                            isLoading = false,
+                            generalError = resolveMessage(throwable, "Не удалось зарегистрироваться"),
+                        )
+                    }
+                },
+            )
+        }
+    }
+
+    fun consumeError() {
+        _state.update { it.copy(generalError = null) }
+    }
+
+    private fun observeAuthState() {
+        viewModelScope.launch {
+            authRepository.isAuthenticated.collectLatest { isAuthenticated ->
+                if (isAuthenticated) {
+                    if (!hasNavigated) {
+                        hasNavigated = true
+                        eventsChannel.send(AuthEvent.NavigateToMain)
+                    }
+                } else {
+                    hasNavigated = false
+                }
+            }
+        }
+    }
+
+    private fun validateUsername(username: String): String? = when {
+        username.isBlank() -> "Введите имя пользователя"
+        !USERNAME_REGEX.matches(username) -> "4–15 символов: буквы, цифры или _"
+        else -> null
+    }
+
+    private fun validatePassword(password: String): String? = when {
+        password.isBlank() -> "Введите пароль"
+        !USERNAME_REGEX.matches(password) -> "4–15 символов: буквы, цифры или _"
+        else -> null
+    }
+
+    private fun resolveMessage(throwable: Throwable, defaultMessage: String): String = when (throwable) {
+        is AuthRepositoryException -> throwable.message ?: defaultMessage
+        else -> throwable.message ?: defaultMessage
+    }
+
+    companion object {
+        private val USERNAME_REGEX = Regex("^[a-zA-Z0-9_]{4,15}$")
+    }
+}
+
+data class AuthViewState(
+    val selectedTab: AuthTab = AuthTab.LOGIN,
+    val isLoading: Boolean = false,
+    val usernameError: String? = null,
+    val passwordError: String? = null,
+    val confirmPasswordError: String? = null,
+    val generalError: String? = null,
+)
+
+enum class AuthTab { LOGIN, REGISTER }
+
+sealed interface AuthEvent {
+    object NavigateToMain : AuthEvent
+    data class ShowMessage(val message: String) : AuthEvent
+}

--- a/android/src/main/java/com/example/zazeks/ui/menu/MainMenuFragment.kt
+++ b/android/src/main/java/com/example/zazeks/ui/menu/MainMenuFragment.kt
@@ -6,10 +6,15 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.lifecycleScope
+import androidx.navigation.NavOptions
 import androidx.navigation.fragment.findNavController
 import com.example.zazeks.R
+import com.example.zazeks.data.auth.AuthRepository
 import com.example.zazeks.databinding.FragmentMainMenuBinding
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
+import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class MainMenuFragment : Fragment() {
@@ -18,6 +23,9 @@ class MainMenuFragment : Fragment() {
     private val binding get() = _binding!!
 
     private val viewModel: MainMenuViewModel by viewModels()
+
+    @Inject
+    lateinit var authRepository: AuthRepository
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -45,6 +53,20 @@ class MainMenuFragment : Fragment() {
         }
         binding.openResultsButton.setOnClickListener {
             findNavController().navigate(R.id.action_mainMenuFragment_to_resultsFragment)
+        }
+        binding.logoutButton.setOnClickListener {
+            binding.logoutButton.isEnabled = false
+            viewLifecycleOwner.lifecycleScope.launch {
+                try {
+                    authRepository.logout()
+                    val navOptions = NavOptions.Builder()
+                        .setPopUpTo(R.id.nav_graph, true)
+                        .build()
+                    findNavController().navigate(R.id.authFragment, null, navOptions)
+                } finally {
+                    binding.logoutButton.isEnabled = true
+                }
+            }
         }
 
         viewModel.state.observe(viewLifecycleOwner) { state ->

--- a/android/src/main/res/layout/fragment_auth.xml
+++ b/android/src/main/res/layout/fragment_auth.xml
@@ -1,0 +1,200 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fillViewport="true">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="24dp">
+
+        <TextView
+            android:id="@+id/authTitle"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:text="@string/auth_title"
+            android:textAppearance="@style/TextAppearance.MaterialComponents.Headline5"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/authSubtitle"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:text="@string/auth_subtitle"
+            android:textAppearance="@style/TextAppearance.MaterialComponents.Body1"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/authTitle" />
+
+        <com.google.android.material.tabs.TabLayout
+            android:id="@+id/authTabs"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            app:tabIndicatorFullWidth="false"
+            app:tabMode="fixed"
+            app:tabRippleColor="@android:color/transparent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/authSubtitle">
+
+            <com.google.android.material.tabs.TabItem
+                android:text="@string/auth_tab_login" />
+
+            <com.google.android.material.tabs.TabItem
+                android:text="@string/auth_tab_register" />
+        </com.google.android.material.tabs.TabLayout>
+
+        <LinearLayout
+            android:id="@+id/loginForm"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:orientation="vertical"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/authTabs">
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/loginUsernameInputLayout"
+                style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="16dp">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/loginUsernameInput"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:imeOptions="actionNext"
+                    android:inputType="text"
+                    android:maxLines="1"
+                    android:hint="@string/auth_username_hint" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/loginPasswordInputLayout"
+                style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/loginPasswordInput"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/auth_password_hint"
+                    android:imeOptions="actionDone"
+                    android:inputType="textPassword"
+                    android:maxLines="1" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/loginSubmitButton"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="24dp"
+                android:text="@string/auth_login_button" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/registerForm"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:orientation="vertical"
+            android:visibility="gone"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/authTabs">
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/registerUsernameInputLayout"
+                style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="16dp">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/registerUsernameInput"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/auth_username_hint"
+                    android:imeOptions="actionNext"
+                    android:inputType="text"
+                    android:maxLines="1" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/registerPasswordInputLayout"
+                style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="16dp">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/registerPasswordInput"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/auth_password_hint"
+                    android:imeOptions="actionNext"
+                    android:inputType="textPassword"
+                    android:maxLines="1" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/registerConfirmInputLayout"
+                style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/registerConfirmInput"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/auth_confirm_password_hint"
+                    android:imeOptions="actionDone"
+                    android:inputType="textPassword"
+                    android:maxLines="1" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/registerSubmitButton"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="24dp"
+                android:text="@string/auth_register_button" />
+        </LinearLayout>
+
+        <androidx.constraintlayout.widget.Barrier
+            android:id="@+id/formBarrier"
+            app:barrierDirection="bottom"
+            app:constraint_referenced_ids="loginForm,registerForm" />
+
+        <TextView
+            android:id="@+id/errorText"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:textColor="@android:color/holo_red_dark"
+            android:visibility="gone"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/formBarrier" />
+
+        <com.google.android.material.progressindicator.CircularProgressIndicator
+            android:id="@+id/loadingIndicator"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:visibility="gone"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/errorText" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</androidx.core.widget.NestedScrollView>

--- a/android/src/main/res/layout/fragment_main_menu.xml
+++ b/android/src/main/res/layout/fragment_main_menu.xml
@@ -67,4 +67,15 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
 
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/logoutButton"
+        style="@style/Widget.MaterialComponents.Button.TextButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="@string/auth_logout"
+        app:layout_constraintTop_toBottomOf="@id/openResultsButton"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/android/src/main/res/navigation/nav_graph.xml
+++ b/android/src/main/res/navigation/nav_graph.xml
@@ -2,12 +2,28 @@
 <navigation xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/nav_graph"
-    app:startDestination="@id/mainMenuFragment">
+    app:startDestination="@id/authFragment">
+
+    <fragment
+        android:id="@+id/authFragment"
+        android:name="com.example.zazeks.ui.auth.AuthFragment"
+        android:label="@string/app_name">
+        <action
+            android:id="@+id/action_authFragment_to_mainMenuFragment"
+            app:destination="@id/mainMenuFragment"
+            app:popUpTo="@id/authFragment"
+            app:popUpToInclusive="true" />
+    </fragment>
 
     <fragment
         android:id="@+id/mainMenuFragment"
         android:name="com.example.zazeks.ui.menu.MainMenuFragment"
         android:label="@string/menu_title">
+        <action
+            android:id="@+id/action_mainMenuFragment_to_authFragment"
+            app:destination="@id/authFragment"
+            app:popUpTo="@id/nav_graph"
+            app:popUpToInclusive="true" />
         <action
             android:id="@+id/action_mainMenuFragment_to_offlineMatchFragment"
             app:destination="@id/offlineMatchFragment" />

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -71,4 +71,15 @@
     <string name="online_play_again">Сыграть ещё</string>
     <string name="online_results_button">В результаты</string>
     <string name="online_status_waiting">Ожидание соперника…</string>
+    <string name="auth_title">Добро пожаловать</string>
+    <string name="auth_subtitle">Войдите или создайте аккаунт, чтобы продолжить</string>
+    <string name="auth_tab_login">Вход</string>
+    <string name="auth_tab_register">Регистрация</string>
+    <string name="auth_username_hint">Имя пользователя</string>
+    <string name="auth_password_hint">Пароль</string>
+    <string name="auth_confirm_password_hint">Повторите пароль</string>
+    <string name="auth_login_button">Войти</string>
+    <string name="auth_register_button">Создать аккаунт</string>
+    <string name="auth_error_generic">Что-то пошло не так. Попробуйте снова.</string>
+    <string name="auth_logout">Выйти</string>
 </resources>


### PR DESCRIPTION
## Summary
- add Retrofit and DataStore wiring including token persistence and authorization interceptor
- implement authentication repository, view model, and fragment UI with form validation and tabbed login/registration flow
- update navigation and main menu to start with authentication and support logout back to the form

## Testing
- `./gradlew lint --console=plain --no-daemon` *(fails: missing Java 17 toolchain in container)*

------
https://chatgpt.com/codex/tasks/task_e_6904996cc9ac8333a408f7e9b9390ca8