### PR TITLE
Add profile screen with user management

### DIFF
--- a/android/src/main/java/com/example/zazeks/data/user/NetworkUserRepository.kt
+++ b/android/src/main/java/com/example/zazeks/data/user/NetworkUserRepository.kt
@@ -1,0 +1,74 @@
+package com.example.zazeks.data.user
+
+import android.util.Base64
+import com.example.zazeks.domain.user.UpdateUserProfileParams
+import com.example.zazeks.domain.user.UpdateUserProfileResult
+import com.example.zazeks.domain.user.UserProfile
+import com.example.zazeks.domain.user.UserRepository
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class NetworkUserRepository @Inject constructor(
+    private val api: UserApi,
+) : UserRepository {
+
+    override suspend fun getProfile(userId: Int): UserProfile =
+        api.getUserProfile(userId).toDomain()
+
+    override suspend fun updateProfile(params: UpdateUserProfileParams): UpdateUserProfileResult {
+        validatePhoto(params.photoBase64)
+        val response = api.updateUserProfile(
+            params.userId,
+            UpdateUserRequest(
+                username = params.username?.takeIf { it.isNotBlank() },
+                photo = params.photoBase64?.takeIf { it.isNotBlank() },
+            )
+        )
+        val profileDto = response.user ?: throw UserRepositoryException("Отсутствуют данные профиля")
+        return UpdateUserProfileResult(
+            message = response.message ?: "Профиль обновлён",
+            profile = profileDto.toDomain(),
+        )
+    }
+
+    private fun validatePhoto(photo: String?) {
+        if (photo.isNullOrBlank()) return
+        val parts = photo.split(",", limit = 2)
+        if (parts.size != 2) {
+            throw UserRepositoryException("Некорректный формат изображения")
+        }
+        val header = parts[0].lowercase()
+        if (!header.startsWith("data:image/")) {
+            throw UserRepositoryException("Некорректный формат изображения")
+        }
+        val mimeType = header.substringAfter("data:image/").substringBefore(";")
+        if (mimeType != "png" && mimeType != "jpeg" && mimeType != "jpg") {
+            throw UserRepositoryException("Допускаются только PNG или JPG изображения")
+        }
+        val decoded = try {
+            Base64.decode(parts[1], Base64.DEFAULT)
+        } catch (error: IllegalArgumentException) {
+            throw UserRepositoryException("Некорректный формат изображения", error)
+        }
+        if (decoded.size > MAX_IMAGE_SIZE_BYTES) {
+            throw UserRepositoryException("Размер изображения не должен превышать 5 МБ")
+        }
+    }
+
+    private fun UserProfileDto.toDomain(): UserProfile = UserProfile(
+        id = id ?: throw UserRepositoryException("Некорректные данные профиля"),
+        username = username.orEmpty(),
+        photo = photo,
+        wins = wins ?: 0,
+        gamesPlayed = gamesPlayed ?: 0,
+        onlineWins = onlineWins ?: 0,
+        onlineGames = onlineGames ?: 0,
+    )
+
+    companion object {
+        private const val MAX_IMAGE_SIZE_BYTES = 5 * 1024 * 1024
+    }
+}
+
+class UserRepositoryException(message: String, cause: Throwable? = null) : Exception(message, cause)

--- a/android/src/main/java/com/example/zazeks/data/user/UserApi.kt
+++ b/android/src/main/java/com/example/zazeks/data/user/UserApi.kt
@@ -1,0 +1,17 @@
+package com.example.zazeks.data.user
+
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.PUT
+import retrofit2.http.Path
+
+interface UserApi {
+    @GET("users/{id}")
+    suspend fun getUserProfile(@Path("id") userId: Int): UserProfileDto
+
+    @PUT("users/{id}")
+    suspend fun updateUserProfile(
+        @Path("id") userId: Int,
+        @Body request: UpdateUserRequest,
+    ): UpdateUserResponse
+}

--- a/android/src/main/java/com/example/zazeks/data/user/UserProfileDto.kt
+++ b/android/src/main/java/com/example/zazeks/data/user/UserProfileDto.kt
@@ -1,0 +1,21 @@
+package com.example.zazeks.data.user
+
+data class UserProfileDto(
+    val id: Int?,
+    val username: String?,
+    val photo: String?,
+    val wins: Int?,
+    val gamesPlayed: Int?,
+    val onlineWins: Int?,
+    val onlineGames: Int?,
+)
+
+data class UpdateUserRequest(
+    val username: String?,
+    val photo: String?,
+)
+
+data class UpdateUserResponse(
+    val message: String?,
+    val user: UserProfileDto?,
+)

--- a/android/src/main/java/com/example/zazeks/di/NetworkModule.kt
+++ b/android/src/main/java/com/example/zazeks/di/NetworkModule.kt
@@ -2,6 +2,7 @@ package com.example.zazeks.di
 
 import com.example.zazeks.data.auth.AuthApi
 import com.example.zazeks.data.results.GameResultsApi
+import com.example.zazeks.data.user.UserApi
 import com.example.zazeks.infra.auth.AuthInterceptor
 import com.example.zazeks.infra.config.BackendConfig
 import dagger.Module
@@ -41,4 +42,8 @@ object NetworkModule {
     @Singleton
     fun provideGameResultsApi(retrofit: Retrofit): GameResultsApi =
         retrofit.create(GameResultsApi::class.java)
+
+    @Provides
+    @Singleton
+    fun provideUserApi(retrofit: Retrofit): UserApi = retrofit.create(UserApi::class.java)
 }

--- a/android/src/main/java/com/example/zazeks/di/UserModule.kt
+++ b/android/src/main/java/com/example/zazeks/di/UserModule.kt
@@ -1,0 +1,30 @@
+package com.example.zazeks.di
+
+import com.example.zazeks.data.user.NetworkUserRepository
+import com.example.zazeks.domain.user.GetUserProfileUseCase
+import com.example.zazeks.domain.user.UpdateUserProfileUseCase
+import com.example.zazeks.domain.user.UserRepository
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object UserModule {
+
+    @Provides
+    @Singleton
+    fun provideUserRepository(repository: NetworkUserRepository): UserRepository = repository
+
+    @Provides
+    @Singleton
+    fun provideGetUserProfileUseCase(repository: UserRepository): GetUserProfileUseCase =
+        GetUserProfileUseCase(repository)
+
+    @Provides
+    @Singleton
+    fun provideUpdateUserProfileUseCase(repository: UserRepository): UpdateUserProfileUseCase =
+        UpdateUserProfileUseCase(repository)
+}

--- a/android/src/main/java/com/example/zazeks/domain/user/GetUserProfileUseCase.kt
+++ b/android/src/main/java/com/example/zazeks/domain/user/GetUserProfileUseCase.kt
@@ -1,0 +1,9 @@
+package com.example.zazeks.domain.user
+
+import javax.inject.Inject
+
+class GetUserProfileUseCase @Inject constructor(
+    private val repository: UserRepository,
+) {
+    suspend operator fun invoke(userId: Int): UserProfile = repository.getProfile(userId)
+}

--- a/android/src/main/java/com/example/zazeks/domain/user/UpdateUserProfileParams.kt
+++ b/android/src/main/java/com/example/zazeks/domain/user/UpdateUserProfileParams.kt
@@ -1,0 +1,7 @@
+package com.example.zazeks.domain.user
+
+data class UpdateUserProfileParams(
+    val userId: Int,
+    val username: String?,
+    val photoBase64: String?,
+)

--- a/android/src/main/java/com/example/zazeks/domain/user/UpdateUserProfileResult.kt
+++ b/android/src/main/java/com/example/zazeks/domain/user/UpdateUserProfileResult.kt
@@ -1,0 +1,6 @@
+package com.example.zazeks.domain.user
+
+data class UpdateUserProfileResult(
+    val message: String,
+    val profile: UserProfile,
+)

--- a/android/src/main/java/com/example/zazeks/domain/user/UpdateUserProfileUseCase.kt
+++ b/android/src/main/java/com/example/zazeks/domain/user/UpdateUserProfileUseCase.kt
@@ -1,0 +1,10 @@
+package com.example.zazeks.domain.user
+
+import javax.inject.Inject
+
+class UpdateUserProfileUseCase @Inject constructor(
+    private val repository: UserRepository,
+) {
+    suspend operator fun invoke(params: UpdateUserProfileParams): UpdateUserProfileResult =
+        repository.updateProfile(params)
+}

--- a/android/src/main/java/com/example/zazeks/domain/user/UserProfile.kt
+++ b/android/src/main/java/com/example/zazeks/domain/user/UserProfile.kt
@@ -1,0 +1,17 @@
+package com.example.zazeks.domain.user
+
+data class UserProfile(
+    val id: Int,
+    val username: String,
+    val photo: String?,
+    val wins: Int,
+    val gamesPlayed: Int,
+    val onlineWins: Int,
+    val onlineGames: Int,
+) {
+    val totalWins: Int get() = wins + onlineWins
+    val totalGames: Int get() = gamesPlayed + onlineGames
+
+    val winRate: Float?
+        get() = if (totalGames > 0) totalWins.toFloat() / totalGames.toFloat() else null
+}

--- a/android/src/main/java/com/example/zazeks/domain/user/UserRepository.kt
+++ b/android/src/main/java/com/example/zazeks/domain/user/UserRepository.kt
@@ -1,0 +1,6 @@
+package com.example.zazeks.domain.user
+
+interface UserRepository {
+    suspend fun getProfile(userId: Int): UserProfile
+    suspend fun updateProfile(params: UpdateUserProfileParams): UpdateUserProfileResult
+}

--- a/android/src/main/java/com/example/zazeks/ui/common/ImageViewExtensions.kt
+++ b/android/src/main/java/com/example/zazeks/ui/common/ImageViewExtensions.kt
@@ -1,0 +1,30 @@
+package com.example.zazeks.ui.common
+
+import android.graphics.BitmapFactory
+import android.graphics.drawable.Drawable
+import android.util.Base64
+import android.widget.ImageView
+
+fun ImageView.loadBase64Image(
+    base64: String?,
+    placeholder: Drawable? = null,
+) {
+    if (base64.isNullOrBlank()) {
+        setImageDrawable(placeholder)
+        return
+    }
+    val parts = base64.split(",", limit = 2)
+    val encoded = if (parts.size == 2) parts[1] else base64
+    val bytes = try {
+        Base64.decode(encoded, Base64.DEFAULT)
+    } catch (error: IllegalArgumentException) {
+        setImageDrawable(placeholder)
+        return
+    }
+    val bitmap = BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
+    if (bitmap != null) {
+        setImageBitmap(bitmap)
+    } else {
+        setImageDrawable(placeholder)
+    }
+}

--- a/android/src/main/java/com/example/zazeks/ui/menu/MainMenuFragment.kt
+++ b/android/src/main/java/com/example/zazeks/ui/menu/MainMenuFragment.kt
@@ -4,6 +4,9 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
+import androidx.core.content.ContextCompat
+import androidx.core.os.bundleOf
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
@@ -16,6 +19,8 @@ import com.example.zazeks.databinding.FragmentMainMenuBinding
 import com.example.zazeks.databinding.ItemMainMenuResultBinding
 import com.example.zazeks.domain.results.ResultMode
 import com.example.zazeks.domain.results.RoundResult
+import com.example.zazeks.ui.common.loadBase64Image
+import com.example.zazeks.ui.profile.ProfileFragment
 import dagger.hilt.android.AndroidEntryPoint
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
@@ -65,6 +70,8 @@ class MainMenuFragment : Fragment() {
                 Bundle().apply { putBoolean(ARG_RESUME_GAME, true) }
             )
         }
+        binding.profileCard.setOnClickListener { openProfile() }
+        binding.profileMenuButton.setOnClickListener { openProfile() }
         binding.resultsLink.setOnClickListener {
             findNavController().navigate(R.id.action_mainMenuFragment_to_resultsFragment)
         }
@@ -84,12 +91,26 @@ class MainMenuFragment : Fragment() {
         }
 
         viewModel.state.observe(viewLifecycleOwner, ::renderState)
+        parentFragmentManager.setFragmentResultListener(
+            ProfileFragment.REQUEST_KEY_PROFILE_UPDATED,
+            viewLifecycleOwner
+        ) { _, _ ->
+            viewModel.refresh()
+        }
     }
 
     private fun renderState(state: MainMenuViewState) {
-        binding.profileName.text = formatProfileName(state.profileUserId)
-        binding.profileSubtitle.text = formatProfileSubtitle(state.profileUserId)
+        binding.profileName.text = formatProfileName(state)
+        binding.profileSubtitle.text = formatProfileSubtitle(state)
         binding.profileAvatar.contentDescription = binding.profileName.text
+        val placeholder = ContextCompat.getDrawable(requireContext(), android.R.drawable.ic_menu_myplaces)
+        binding.profileAvatar.loadBase64Image(state.profile?.photo, placeholder)
+        val hasProfile = state.profileUserId != null
+        binding.profileCard.isEnabled = hasProfile
+        binding.profileCard.isClickable = hasProfile
+        binding.profileCard.alpha = if (hasProfile) 1f else 0.6f
+        binding.profileMenuButton.isEnabled = hasProfile
+        binding.profileMenuButton.alpha = if (hasProfile) 1f else 0.5f
 
         binding.resumeOfflineButton.isVisible = state.canResume
         binding.resumeOfflineButton.isEnabled = state.canResume
@@ -179,13 +200,17 @@ class MainMenuFragment : Fragment() {
         _binding = null
     }
 
-    private fun formatProfileName(userId: Int?): String = userId?.let {
-        getString(R.string.menu_profile_user_format, it)
-    } ?: getString(R.string.menu_profile_guest)
+    private fun formatProfileName(state: MainMenuViewState): String =
+        state.profile?.username
+            ?: state.profileUserId?.let { getString(R.string.menu_profile_user_format, it) }
+            ?: getString(R.string.menu_profile_guest)
 
-    private fun formatProfileSubtitle(userId: Int?): String = userId?.let {
-        getString(R.string.menu_profile_description_user)
-    } ?: getString(R.string.menu_profile_description_guest)
+    private fun formatProfileSubtitle(state: MainMenuViewState): String =
+        if (state.profileUserId != null) {
+            getString(R.string.menu_profile_description_user)
+        } else {
+            getString(R.string.menu_profile_description_guest)
+        }
 
     private fun formatGesture(value: String?): String = when (value?.lowercase()) {
         "rock" -> getString(R.string.game_select_rock)
@@ -210,6 +235,16 @@ class MainMenuFragment : Fragment() {
 
     private fun formatTimestamp(instant: java.time.Instant?): String? = instant?.let {
         timestampFormatter.format(it)
+    }
+
+    private fun openProfile() {
+        val userId = viewModel.state.value?.profile?.id ?: viewModel.state.value?.profileUserId
+        if (userId != null) {
+            val args = bundleOf(ProfileFragment.ARG_USER_ID to userId)
+            findNavController().navigate(R.id.action_mainMenuFragment_to_profileFragment, args)
+        } else {
+            Toast.makeText(requireContext(), R.string.menu_profile_guest, Toast.LENGTH_SHORT).show()
+        }
     }
 
     companion object {

--- a/android/src/main/java/com/example/zazeks/ui/menu/MainMenuViewModel.kt
+++ b/android/src/main/java/com/example/zazeks/ui/menu/MainMenuViewModel.kt
@@ -12,6 +12,8 @@ import com.example.zazeks.domain.game.GetLastCompletedGameUseCase
 import com.example.zazeks.domain.results.GetUserGameRoundsUseCase
 import com.example.zazeks.domain.results.ResultMode
 import com.example.zazeks.domain.results.RoundResult
+import com.example.zazeks.domain.user.GetUserProfileUseCase
+import com.example.zazeks.domain.user.UserProfile
 import com.example.zazeks.infra.auth.AuthTokenStorage
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
@@ -22,6 +24,7 @@ class MainMenuViewModel @Inject constructor(
     private val getActiveGameSnapshot: GetActiveGameSnapshotUseCase,
     private val getLastCompletedGame: GetLastCompletedGameUseCase,
     private val getUserGameRounds: GetUserGameRoundsUseCase,
+    private val getUserProfile: GetUserProfileUseCase,
     private val authTokenStorage: AuthTokenStorage,
 ) : ViewModel() {
 
@@ -50,8 +53,13 @@ class MainMenuViewModel @Inject constructor(
                     )
             } ?: (emptyList<RoundResult>() to null)
 
+            val profile = session?.userId?.let { userId ->
+                runCatching { getUserProfile(userId) }.getOrNull()
+            }
+
             val stateValue = MainMenuViewState(
                 profileUserId = session?.userId,
+                profile = profile,
                 canResume = active?.isMatchCompleted?.not() == true,
                 lastOffline = lastCompleted?.takeIf { it.isMatchCompleted }?.toRoundResult(),
                 topResults = topResults,
@@ -80,6 +88,7 @@ class MainMenuViewModel @Inject constructor(
 
 data class MainMenuViewState(
     val profileUserId: Int? = null,
+    val profile: UserProfile? = null,
     val canResume: Boolean = false,
     val lastOffline: RoundResult? = null,
     val topResults: List<RoundResult> = emptyList(),

--- a/android/src/main/java/com/example/zazeks/ui/profile/ProfileFragment.kt
+++ b/android/src/main/java/com/example/zazeks/ui/profile/ProfileFragment.kt
@@ -1,0 +1,215 @@
+package com.example.zazeks.ui.profile
+import android.net.Uri
+import android.os.Bundle
+import android.util.Base64
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Toast
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.content.ContextCompat
+import androidx.core.os.bundleOf
+import androidx.core.view.isVisible
+import androidx.core.widget.doAfterTextChanged
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.setFragmentResult
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.lifecycleScope
+import androidx.navigation.fragment.findNavController
+import com.example.zazeks.R
+import com.example.zazeks.databinding.FragmentProfileBinding
+import com.example.zazeks.ui.common.loadBase64Image
+import dagger.hilt.android.AndroidEntryPoint
+import java.io.IOException
+import java.util.Locale
+import kotlin.math.roundToInt
+import kotlinx.coroutines.flow.collectLatest
+
+@AndroidEntryPoint
+class ProfileFragment : Fragment() {
+
+    private var _binding: FragmentProfileBinding? = null
+    private val binding get() = _binding!!
+
+    private val viewModel: ProfileViewModel by viewModels()
+
+    private val pickImageLauncher = registerForActivityResult(
+        ActivityResultContracts.GetContent()
+    ) { uri ->
+        if (uri != null) {
+            handleSelectedImage(uri)
+        }
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        _binding = FragmentProfileBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        binding.profileToolbar.setNavigationOnClickListener {
+            findNavController().navigateUp()
+        }
+        binding.profileRetryButton.setOnClickListener { viewModel.loadProfile() }
+        binding.profileEditButton.setOnClickListener { viewModel.startEditing() }
+        binding.profileCancelButton.setOnClickListener { viewModel.cancelEditing() }
+        binding.profileSaveButton.setOnClickListener { viewModel.saveChanges() }
+        binding.profileChangePhotoButton.setOnClickListener { pickImageLauncher.launch("image/*") }
+        binding.profileUsernameInput.doAfterTextChanged { editable ->
+            if (binding.profileUsernameInput.hasFocus()) {
+                viewModel.onUsernameChanged(editable?.toString().orEmpty())
+            }
+        }
+
+        viewModel.state.observe(viewLifecycleOwner, ::renderState)
+        viewLifecycleOwner.lifecycleScope.launchWhenStarted {
+            viewModel.events.collectLatest(::handleEvent)
+        }
+    }
+
+    private fun renderState(state: ProfileViewState) {
+        binding.profileLoading.isVisible = state.isLoading
+        val hasError = state.loadError != null
+        binding.profileErrorContainer.isVisible = hasError && !state.isLoading
+        binding.profileScroll.isVisible = !state.isLoading && !hasError
+
+        when (val error = state.loadError) {
+            is ProfileViewModel.ProfileError.Load -> {
+                binding.profileErrorText.text = error.message ?: getString(R.string.profile_error_load)
+                binding.profileRetryButton.isVisible = true
+            }
+            ProfileViewModel.ProfileError.InvalidUser -> {
+                binding.profileErrorText.text = getString(R.string.profile_invalid_user)
+                binding.profileRetryButton.isVisible = false
+            }
+            null -> Unit
+        }
+
+        val placeholder = ContextCompat.getDrawable(requireContext(), android.R.drawable.ic_menu_myplaces)
+        val avatarSource = state.pendingAvatarBase64 ?: state.profile?.photo
+        binding.profileAvatar.loadBase64Image(avatarSource, placeholder)
+
+        binding.profileUsername.text = state.profile?.username.orEmpty()
+
+        val isEditing = state.isEditing
+        binding.profileUsername.isVisible = !isEditing
+        binding.profileUsernameInputLayout.isVisible = isEditing
+        binding.profileChangePhotoButton.isVisible = isEditing
+        binding.profileSaveButton.isVisible = isEditing
+        binding.profileCancelButton.isVisible = isEditing
+        binding.profileEditButton.isVisible = !isEditing
+        binding.profileEditButton.isEnabled = state.profile != null
+        binding.profileSaveButton.isEnabled = !state.isSaving
+        binding.profileChangePhotoButton.isEnabled = !state.isSaving
+        binding.profileCancelButton.isEnabled = !state.isSaving
+
+        if (isEditing) {
+            val currentText = binding.profileUsernameInput.text?.toString().orEmpty()
+            if (currentText != state.usernameInput) {
+                binding.profileUsernameInput.setText(state.usernameInput)
+                binding.profileUsernameInput.setSelection(state.usernameInput.length)
+            }
+        } else {
+            binding.profileUsernameInput.setText("")
+        }
+
+        val profile = state.profile
+        val offlineWins = profile?.wins ?: 0
+        val offlineGames = profile?.gamesPlayed ?: 0
+        val onlineWins = profile?.onlineWins ?: 0
+        val onlineGames = profile?.onlineGames ?: 0
+
+        binding.profileOfflineWins.text = getString(R.string.profile_stat_wins_format, offlineWins)
+        binding.profileOfflineGames.text = getString(R.string.profile_stat_games_format, offlineGames)
+        binding.profileOnlineWins.text = getString(R.string.profile_stat_wins_format, onlineWins)
+        binding.profileOnlineGames.text = getString(R.string.profile_stat_games_format, onlineGames)
+
+        val winRate = profile?.winRate
+        if (winRate != null) {
+            val percentage = (winRate * 100).coerceIn(0f, 100f)
+            binding.profileWinrateValue.text = getString(R.string.profile_winrate_value, percentage)
+            binding.profileWinrateProgress.isVisible = true
+            binding.profileWinrateProgress.setProgressCompat(percentage.roundToInt(), false)
+        } else {
+            binding.profileWinrateValue.text = getString(R.string.profile_winrate_unknown)
+            binding.profileWinrateProgress.isVisible = true
+            binding.profileWinrateProgress.setProgressCompat(0, false)
+        }
+    }
+
+    private fun handleEvent(event: ProfileEvent) {
+        when (event) {
+            is ProfileEvent.ShowMessage -> {
+                val message = event.message?.takeIf { it.isNotBlank() }
+                    ?: getString(R.string.profile_update_success)
+                showToast(message)
+            }
+            is ProfileEvent.ShowError -> {
+                val message = event.message
+                    .takeUnless { it.isBlank() || it.startsWith("HTTP", ignoreCase = true) }
+                    ?: getString(R.string.profile_update_error)
+                showToast(message)
+            }
+            is ProfileEvent.ProfileUpdated -> {
+                setFragmentResult(
+                    REQUEST_KEY_PROFILE_UPDATED,
+                    bundleOf(RESULT_KEY_PROFILE_UPDATED to true)
+                )
+            }
+        }
+    }
+
+    private fun handleSelectedImage(uri: Uri) {
+        val context = requireContext()
+        val result = runCatching {
+            val resolver = context.contentResolver
+            val mimeType = resolver.getType(uri)?.lowercase(Locale.ROOT)
+                ?: throw IllegalArgumentException(getString(R.string.profile_avatar_error_type))
+            if (mimeType != MIME_PNG && mimeType != MIME_JPEG && mimeType != MIME_JPG) {
+                throw IllegalArgumentException(getString(R.string.profile_avatar_error_type))
+            }
+            val bytes = resolver.openInputStream(uri)?.use { input -> input.readBytes() }
+                ?: throw IOException("Unable to read image")
+            if (bytes.size > MAX_IMAGE_SIZE_BYTES) {
+                throw IllegalArgumentException(getString(R.string.profile_avatar_error_size))
+            }
+            val normalizedMime = if (mimeType == MIME_JPG) MIME_JPEG else mimeType
+            val base64 = Base64.encodeToString(bytes, Base64.NO_WRAP)
+            "data:$normalizedMime;base64,$base64"
+        }
+        result.onSuccess { base64 ->
+            viewModel.onAvatarSelected(base64)
+        }.onFailure { error ->
+            val message = when (error) {
+                is IllegalArgumentException -> error.message
+                else -> getString(R.string.profile_update_error)
+            }
+            showToast(message ?: getString(R.string.profile_update_error))
+        }
+    }
+
+    private fun showToast(message: String) {
+        if (!isAdded) return
+        Toast.makeText(requireContext(), message, Toast.LENGTH_SHORT).show()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+    companion object {
+        const val ARG_USER_ID = "userId"
+        const val REQUEST_KEY_PROFILE_UPDATED = "profile_updated"
+        const val RESULT_KEY_PROFILE_UPDATED = "profile_updated_result"
+        private const val MAX_IMAGE_SIZE_BYTES = 5 * 1024 * 1024
+        private const val MIME_PNG = "image/png"
+        private const val MIME_JPEG = "image/jpeg"
+        private const val MIME_JPG = "image/jpg"
+    }
+}

--- a/android/src/main/java/com/example/zazeks/ui/profile/ProfileViewModel.kt
+++ b/android/src/main/java/com/example/zazeks/ui/profile/ProfileViewModel.kt
@@ -1,0 +1,166 @@
+package com.example.zazeks.ui.profile
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.zazeks.domain.user.GetUserProfileUseCase
+import com.example.zazeks.domain.user.UpdateUserProfileParams
+import com.example.zazeks.domain.user.UpdateUserProfileUseCase
+import com.example.zazeks.domain.user.UserProfile
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.launch
+
+@HiltViewModel
+class ProfileViewModel @Inject constructor(
+    private val getUserProfile: GetUserProfileUseCase,
+    private val updateUserProfile: UpdateUserProfileUseCase,
+    savedStateHandle: SavedStateHandle,
+) : ViewModel() {
+
+    private val userId: Int = savedStateHandle.get<Int>(ProfileFragment.ARG_USER_ID) ?: INVALID_USER_ID
+
+    private val mutableState = MutableLiveData(ProfileViewState())
+    val state: LiveData<ProfileViewState> = mutableState
+
+    private val mutableEvents = MutableSharedFlow<ProfileEvent>()
+    val events: SharedFlow<ProfileEvent> = mutableEvents.asSharedFlow()
+
+    init {
+        if (userId == INVALID_USER_ID) {
+            mutableState.value = ProfileViewState(
+                isLoading = false,
+                loadError = ProfileError.InvalidUser,
+            )
+        } else {
+            loadProfile()
+        }
+    }
+
+    fun loadProfile() {
+        if (userId == INVALID_USER_ID) return
+        viewModelScope.launch {
+            updateState { it.copy(isLoading = true, loadError = null) }
+            runCatching { getUserProfile(userId) }
+                .onSuccess { profile ->
+                    updateState {
+                        it.copy(
+                            isLoading = false,
+                            loadError = null,
+                            profile = profile,
+                            usernameInput = profile.username,
+                            pendingAvatarBase64 = null,
+                            isEditing = false,
+                        )
+                    }
+                }
+                .onFailure { error ->
+                    updateState {
+                        it.copy(
+                            isLoading = false,
+                            loadError = ProfileError.Load(error.message),
+                        )
+                    }
+                }
+        }
+    }
+
+    fun startEditing() {
+        val profile = state.value?.profile ?: return
+        updateState {
+            it.copy(
+                isEditing = true,
+                usernameInput = profile.username,
+                pendingAvatarBase64 = null,
+            )
+        }
+    }
+
+    fun cancelEditing() {
+        val profile = state.value?.profile
+        updateState {
+            it.copy(
+                isEditing = false,
+                usernameInput = profile?.username.orEmpty(),
+                pendingAvatarBase64 = null,
+                isSaving = false,
+            )
+        }
+    }
+
+    fun onUsernameChanged(value: String) {
+        updateState { it.copy(usernameInput = value) }
+    }
+
+    fun onAvatarSelected(base64: String) {
+        updateState { it.copy(pendingAvatarBase64 = base64) }
+    }
+
+    fun saveChanges() {
+        val current = state.value ?: return
+        val profile = current.profile ?: return
+        if (!current.isEditing || current.isSaving) return
+
+        val username = current.usernameInput.trim().takeIf { it.isNotBlank() && it != profile.username }
+        val photo = current.pendingAvatarBase64
+        if (username == null && photo == null) {
+            cancelEditing()
+            return
+        }
+        updateState { it.copy(isSaving = true) }
+        viewModelScope.launch {
+            runCatching {
+                updateUserProfile(
+                    UpdateUserProfileParams(
+                        userId = profile.id,
+                        username = username,
+                        photoBase64 = photo,
+                    )
+                )
+            }
+                .onSuccess { result ->
+                    updateState {
+                        it.copy(
+                            profile = result.profile,
+                            usernameInput = result.profile.username,
+                            pendingAvatarBase64 = null,
+                            isEditing = false,
+                            isSaving = false,
+                        )
+                    }
+                    mutableEvents.emit(ProfileEvent.ShowMessage(result.message))
+                    mutableEvents.emit(ProfileEvent.ProfileUpdated(result.profile))
+                }
+                .onFailure { error ->
+                    updateState { it.copy(isSaving = false) }
+                    val message = error.message ?: ""
+                    mutableEvents.emit(ProfileEvent.ShowError(message))
+                }
+        }
+    }
+
+    private fun updateState(transform: (ProfileViewState) -> ProfileViewState) {
+        val current = mutableState.value ?: ProfileViewState()
+        mutableState.value = transform(current)
+    }
+
+    sealed class ProfileError {
+        data object InvalidUser : ProfileError()
+        data class Load(val message: String?) : ProfileError()
+    }
+
+    companion object {
+        private const val INVALID_USER_ID = -1
+    }
+}
+
+sealed interface ProfileEvent {
+    data class ShowMessage(val message: String?) : ProfileEvent
+    data class ShowError(val message: String) : ProfileEvent
+    data class ProfileUpdated(val profile: UserProfile) : ProfileEvent
+}

--- a/android/src/main/java/com/example/zazeks/ui/profile/ProfileViewState.kt
+++ b/android/src/main/java/com/example/zazeks/ui/profile/ProfileViewState.kt
@@ -1,0 +1,13 @@
+package com.example.zazeks.ui.profile
+
+import com.example.zazeks.domain.user.UserProfile
+
+data class ProfileViewState(
+    val isLoading: Boolean = true,
+    val loadError: ProfileViewModel.ProfileError? = null,
+    val profile: UserProfile? = null,
+    val isEditing: Boolean = false,
+    val usernameInput: String = "",
+    val pendingAvatarBase64: String? = null,
+    val isSaving: Boolean = false,
+)

--- a/android/src/main/res/drawable/ic_arrow_back.xml
+++ b/android/src/main/res/drawable/ic_arrow_back.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="?attr/colorOnSurface"
+        android:pathData="M20,11H7.83l5.59,-5.59L12,4l-8,8 8,8 1.41,-1.41L7.83,13H20v-2z" />
+</vector>

--- a/android/src/main/res/layout/fragment_main_menu.xml
+++ b/android/src/main/res/layout/fragment_main_menu.xml
@@ -12,18 +12,38 @@
         android:orientation="vertical"
         android:gravity="top">
 
-        <TextView
-            android:id="@+id/menuTitle"
-            android:layout_width="wrap_content"
+        <LinearLayout
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="@string/menu_title"
-            android:textAppearance="@style/TextAppearance.MaterialComponents.Headline4" />
+            android:gravity="center_vertical"
+            android:orientation="horizontal">
+
+            <TextView
+                android:id="@+id/menuTitle"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/menu_title"
+                android:textAppearance="@style/TextAppearance.MaterialComponents.Headline4" />
+
+            <ImageButton
+                android:id="@+id/profileMenuButton"
+                android:layout_width="40dp"
+                android:layout_height="40dp"
+                android:background="?attr/selectableItemBackgroundBorderless"
+                android:contentDescription="@string/profile_title"
+                android:padding="8dp"
+                android:src="@android:drawable/ic_menu_myplaces" />
+        </LinearLayout>
 
         <com.google.android.material.card.MaterialCardView
             android:id="@+id/profileCard"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="24dp"
+            android:clickable="true"
+            android:focusable="true"
+            android:foreground="?attr/selectableItemBackground"
             app:cardUseCompatPadding="true">
 
             <LinearLayout

--- a/android/src/main/res/layout/fragment_profile.xml
+++ b/android/src/main/res/layout/fragment_profile.xml
@@ -1,0 +1,271 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/profileToolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="?attr/colorSurface"
+        android:elevation="4dp"
+        android:theme="@style/ThemeOverlay.MaterialComponents.Toolbar"
+        app:navigationIcon="@drawable/ic_arrow_back"
+        app:title="@string/profile_title" />
+
+    <FrameLayout
+        android:id="@+id/profileContainer"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_marginTop="?attr/actionBarSize"
+        android:padding="24dp">
+
+        <ProgressBar
+            android:id="@+id/profileLoading"
+            style="@style/Widget.MaterialComponents.ProgressIndicator.Circular.Indeterminate"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center" />
+
+        <LinearLayout
+            android:id="@+id/profileErrorContainer"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:gravity="center_horizontal"
+            android:orientation="vertical"
+            android:visibility="gone">
+
+            <TextView
+                android:id="@+id/profileErrorText"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:padding="8dp"
+                android:text="@string/profile_error_load"
+                android:textAppearance="@style/TextAppearance.MaterialComponents.Body1"
+                android:textColor="?attr/colorOnSurfaceVariant" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/profileRetryButton"
+                style="@style/Widget.MaterialComponents.Button"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:text="@string/error_retry" />
+        </LinearLayout>
+
+        <ScrollView
+            android:id="@+id/profileScroll"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:fillViewport="true"
+            android:visibility="gone">
+
+            <LinearLayout
+                android:id="@+id/profileContent"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:gravity="center_horizontal"
+                    android:orientation="vertical"
+                    android:paddingBottom="16dp">
+
+                    <ImageView
+                        android:id="@+id/profileAvatar"
+                        android:layout_width="112dp"
+                        android:layout_height="112dp"
+                        android:background="@drawable/bg_gesture_chip"
+                        android:contentDescription="@string/profile_avatar_content_description"
+                        android:padding="16dp"
+                        android:scaleType="centerCrop"
+                        android:src="@android:drawable/ic_menu_myplaces" />
+
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/profileChangePhotoButton"
+                        style="@style/Widget.MaterialComponents.Button.TextButton"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="12dp"
+                        android:text="@string/profile_change_photo"
+                        android:visibility="gone" />
+                </LinearLayout>
+
+                <TextView
+                    android:id="@+id/profileUsernameLabel"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/profile_username_label"
+                    android:textAppearance="@style/TextAppearance.MaterialComponents.Caption" />
+
+                <TextView
+                    android:id="@+id/profileUsername"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="4dp"
+                    android:textAppearance="@style/TextAppearance.MaterialComponents.Headline5" />
+
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/profileUsernameInputLayout"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="4dp"
+                    android:hint="@string/profile_username_hint"
+                    android:visibility="gone">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/profileUsernameInput"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:imeOptions="actionDone"
+                        android:inputType="textPersonName" />
+                </com.google.android.material.textfield.TextInputLayout>
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="16dp"
+                    android:orientation="horizontal">
+
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/profileEditButton"
+                        style="@style/Widget.MaterialComponents.Button"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_marginEnd="8dp"
+                        android:layout_weight="1"
+                        android:text="@string/profile_edit" />
+
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/profileSaveButton"
+                        style="@style/Widget.MaterialComponents.Button"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="8dp"
+                        android:layout_weight="1"
+                        android:text="@string/profile_save"
+                        android:visibility="gone" />
+                </LinearLayout>
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/profileCancelButton"
+                    style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:text="@string/profile_cancel"
+                    android:visibility="gone" />
+
+                <TextView
+                    android:id="@+id/profileStatsTitle"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="24dp"
+                    android:text="@string/profile_stats_title"
+                    android:textAppearance="@style/TextAppearance.MaterialComponents.Headline6" />
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="12dp"
+                    android:orientation="vertical">
+
+                    <com.google.android.material.card.MaterialCardView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginBottom="12dp">
+
+                        <LinearLayout
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:orientation="vertical"
+                            android:padding="16dp">
+
+                            <TextView
+                                android:id="@+id/profileOfflineTitle"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="@string/profile_stats_offline"
+                                android:textAppearance="@style/TextAppearance.MaterialComponents.Body1" />
+
+                            <TextView
+                                android:id="@+id/profileOfflineWins"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_marginTop="8dp"
+                                android:textAppearance="@style/TextAppearance.MaterialComponents.Body2" />
+
+                            <TextView
+                                android:id="@+id/profileOfflineGames"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_marginTop="4dp"
+                                android:textAppearance="@style/TextAppearance.MaterialComponents.Body2" />
+                        </LinearLayout>
+                    </com.google.android.material.card.MaterialCardView>
+
+                    <com.google.android.material.card.MaterialCardView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content">
+
+                        <LinearLayout
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:orientation="vertical"
+                            android:padding="16dp">
+
+                            <TextView
+                                android:id="@+id/profileOnlineTitle"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="@string/profile_stats_online"
+                                android:textAppearance="@style/TextAppearance.MaterialComponents.Body1" />
+
+                            <TextView
+                                android:id="@+id/profileOnlineWins"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_marginTop="8dp"
+                                android:textAppearance="@style/TextAppearance.MaterialComponents.Body2" />
+
+                            <TextView
+                                android:id="@+id/profileOnlineGames"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_marginTop="4dp"
+                                android:textAppearance="@style/TextAppearance.MaterialComponents.Body2" />
+                        </LinearLayout>
+                    </com.google.android.material.card.MaterialCardView>
+                </LinearLayout>
+
+                <TextView
+                    android:id="@+id/profileWinrateTitle"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="24dp"
+                    android:text="@string/profile_winrate_title"
+                    android:textAppearance="@style/TextAppearance.MaterialComponents.Headline6" />
+
+                <TextView
+                    android:id="@+id/profileWinrateValue"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:textAppearance="@style/TextAppearance.MaterialComponents.Body1" />
+
+                <com.google.android.material.progressindicator.LinearProgressIndicator
+                    android:id="@+id/profileWinrateProgress"
+                    style="@style/Widget.MaterialComponents.LinearProgressIndicator"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:max="100"
+                    app:trackThickness="8dp" />
+            </LinearLayout>
+        </ScrollView>
+    </FrameLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/android/src/main/res/navigation/nav_graph.xml
+++ b/android/src/main/res/navigation/nav_graph.xml
@@ -33,6 +33,9 @@
         <action
             android:id="@+id/action_mainMenuFragment_to_onlineMatchFragment"
             app:destination="@id/onlineMatchFragment" />
+        <action
+            android:id="@+id/action_mainMenuFragment_to_profileFragment"
+            app:destination="@id/profileFragment" />
     </fragment>
 
     <fragment
@@ -78,5 +81,14 @@
         <action
             android:id="@+id/action_resultsFragment_to_onlineMatchFragment"
             app:destination="@id/onlineMatchFragment" />
+    </fragment>
+
+    <fragment
+        android:id="@+id/profileFragment"
+        android:name="com.example.zazeks.ui.profile.ProfileFragment"
+        android:label="@string/profile_title">
+        <argument
+            android:name="userId"
+            android:argType="integer" />
     </fragment>
 </navigation>

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -100,4 +100,26 @@
     <string name="auth_register_button">Создать аккаунт</string>
     <string name="auth_error_generic">Что-то пошло не так. Попробуйте снова.</string>
     <string name="auth_logout">Выйти</string>
+    <string name="profile_title">Профиль</string>
+    <string name="profile_edit">Редактировать</string>
+    <string name="profile_save">Сохранить</string>
+    <string name="profile_cancel">Отмена</string>
+    <string name="profile_change_photo">Изменить фото</string>
+    <string name="profile_stats_title">Статистика</string>
+    <string name="profile_stats_offline">Офлайн статистика</string>
+    <string name="profile_stats_online">Онлайн статистика</string>
+    <string name="profile_stat_wins_format">Победы: %1$d</string>
+    <string name="profile_stat_games_format">Матчи: %1$d</string>
+    <string name="profile_winrate_title">Общий винрейт</string>
+    <string name="profile_winrate_value">Винрейт: %1$.0f%%</string>
+    <string name="profile_winrate_unknown">Винрейт: нет данных</string>
+    <string name="profile_error_load">Не удалось загрузить профиль. Попробуйте снова.</string>
+    <string name="profile_update_success">Профиль обновлён</string>
+    <string name="profile_update_error">Не удалось обновить профиль</string>
+    <string name="profile_avatar_error_type">Допускаются только PNG или JPG изображения</string>
+    <string name="profile_avatar_error_size">Размер изображения не должен превышать 5 МБ</string>
+    <string name="profile_avatar_content_description">Аватар профиля</string>
+    <string name="profile_username_hint">Новое имя пользователя</string>
+    <string name="profile_username_label">Имя пользователя</string>
+    <string name="profile_invalid_user">Пользователь не найден</string>
 </resources>


### PR DESCRIPTION
## Summary
- add a user repository and use cases to fetch and update `/users/{id}` with client-side validation for avatar payloads
- implement the new profile fragment with editable username, avatar picker, and win-rate/statistics UI bound to local state
- hook the profile screen into the main menu navigation with refreshed user data on return

## Testing
- `./gradlew lint --console=plain` *(fails: missing Java 17 toolchain in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_6904a195aec883338f621ac4a60dbe4a