### PR TITLE
Ensure Google repository is configured for Android build

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,6 +6,11 @@ plugins {
     id 'com.google.dagger.hilt.android'
 }
 
+repositories {
+    google()
+    mavenCentral()
+}
+
 import java.util.Properties
 
 android {


### PR DESCRIPTION
## Summary
- add Google and Maven Central repositories to the Android application module so ML Kit dependencies can resolve

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6904ac6495908333aa1615ff790254ce