### PR TITLE
Move project repositories configuration to settings

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,11 +6,6 @@ plugins {
     id 'com.google.dagger.hilt.android'
 }
 
-repositories {
-    google()
-    mavenCentral()
-}
-
 import java.util.Properties
 
 android {


### PR DESCRIPTION
## Summary
- remove the redundant repositories block from `android/build.gradle` to rely on the settings-defined repositories

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6904ad56bc24833391fc5a175b387fd6