### PR TITLE
Fix missing layout dimensions in auth fragment

### DIFF
--- a/android/src/main/res/layout/fragment_auth.xml
+++ b/android/src/main/res/layout/fragment_auth.xml
@@ -44,9 +44,13 @@
             app:layout_constraintTop_toBottomOf="@id/authSubtitle">
 
             <com.google.android.material.tabs.TabItem
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
                 android:text="@string/auth_tab_login" />
 
             <com.google.android.material.tabs.TabItem
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
                 android:text="@string/auth_tab_register" />
         </com.google.android.material.tabs.TabLayout>
 
@@ -172,6 +176,8 @@
 
         <androidx.constraintlayout.widget.Barrier
             android:id="@+id/formBarrier"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
             app:barrierDirection="bottom"
             app:constraint_referenced_ids="loginForm,registerForm" />
 


### PR DESCRIPTION
## Summary
- add explicit layout dimensions to the auth tab items to prevent resource inflation crashes
- give the constraint barrier helper zero-sized layout params to satisfy layout requirements

## Testing
- `./gradlew assembleDebug` *(fails: Java 17 toolchain not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_6905b905fb4083338d93fccd7733eac5