### PR TITLE
Initialize Skill Tracker backend and Android clients

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# Root ignores
+.DS_Store
+*.iml
+.idea/
+.gradle/
+build/
+out/
+!gradle/wrapper/gradle-wrapper.jar
+**/local.properties
+**/.cxx/
+**/.DS_Store

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,0 +1,68 @@
+plugins {
+    id("com.android.application")
+    id("org.jetbrains.kotlin.android")
+    id("kotlin-kapt")
+}
+
+android {
+    namespace = "com.example.skilltracker"
+    compileSdk = 34
+
+    defaultConfig {
+        applicationId = "com.example.skilltracker"
+        minSdk = 24
+        targetSdk = 34
+        versionCode = 1
+        versionName = "1.0"
+
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = false
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+
+    buildFeatures {
+        viewBinding = true
+    }
+}
+
+dependencies {
+    implementation("androidx.core:core-ktx:1.13.1")
+    implementation("androidx.appcompat:appcompat:1.6.1")
+    implementation("com.google.android.material:material:1.11.0")
+    implementation("androidx.constraintlayout:constraintlayout:2.1.4")
+    implementation("androidx.recyclerview:recyclerview:1.3.2")
+
+    implementation("androidx.navigation:navigation-fragment-ktx:2.7.7")
+    implementation("androidx.navigation:navigation-ui-ktx:2.7.7")
+
+    implementation("com.squareup.retrofit2:retrofit:2.11.0")
+    implementation("com.squareup.retrofit2:converter-moshi:2.11.0")
+    implementation("com.squareup.okhttp3:logging-interceptor:4.12.0")
+
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.1")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.1")
+
+    implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.7.0")
+    implementation("androidx.lifecycle:lifecycle-livedata-ktx:2.7.0")
+
+    testImplementation("junit:junit:4.13.2")
+    androidTestImplementation("androidx.test.ext:junit:1.1.5")
+    androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
+}

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -1,0 +1,2 @@
+# Keep Retrofit models
+-keep class com.example.skilltracker.** { *; }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,0 +1,21 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application
+        android:allowBackup="true"
+        android:icon="@mipmap/ic_launcher"
+        android:label="@string/app_name"
+        android:roundIcon="@mipmap/ic_launcher_round"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.SkillTracker">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/android/app/src/main/java/com/example/skilltracker/MainActivity.kt
+++ b/android/app/src/main/java/com/example/skilltracker/MainActivity.kt
@@ -1,0 +1,24 @@
+package com.example.skilltracker
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import androidx.navigation.fragment.NavHostFragment
+import androidx.navigation.ui.setupActionBarWithNavController
+
+class MainActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_main)
+
+        val navHostFragment = supportFragmentManager
+            .findFragmentById(R.id.nav_host_fragment) as NavHostFragment
+        setupActionBarWithNavController(navHostFragment.navController)
+    }
+
+    override fun onSupportNavigateUp(): Boolean {
+        val navHostFragment = supportFragmentManager
+            .findFragmentById(R.id.nav_host_fragment) as NavHostFragment
+        return navHostFragment.navController.navigateUp() || super.onSupportNavigateUp()
+    }
+}

--- a/android/app/src/main/java/com/example/skilltracker/data/api/ApiClient.kt
+++ b/android/app/src/main/java/com/example/skilltracker/data/api/ApiClient.kt
@@ -1,0 +1,29 @@
+package com.example.skilltracker.data.api
+
+import com.squareup.moshi.Moshi
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import retrofit2.Retrofit
+import retrofit2.converter.moshi.MoshiConverterFactory
+
+object ApiClient {
+    private const val BASE_URL = "http://10.0.2.2:8080/"
+
+    private val loggingInterceptor = HttpLoggingInterceptor().apply {
+        level = HttpLoggingInterceptor.Level.BODY
+    }
+
+    private val okHttpClient = OkHttpClient.Builder()
+        .addInterceptor(loggingInterceptor)
+        .build()
+
+    private val retrofit: Retrofit = Retrofit.Builder()
+        .baseUrl(BASE_URL)
+        .client(okHttpClient)
+        .addConverterFactory(MoshiConverterFactory.create(Moshi.Builder().build()))
+        .build()
+
+    val skillApi: SkillApi = retrofit.create(SkillApi::class.java)
+    val sessionApi: SessionApi = retrofit.create(SessionApi::class.java)
+    val statsApi: StatsApi = retrofit.create(StatsApi::class.java)
+}

--- a/android/app/src/main/java/com/example/skilltracker/data/api/SessionApi.kt
+++ b/android/app/src/main/java/com/example/skilltracker/data/api/SessionApi.kt
@@ -1,0 +1,19 @@
+package com.example.skilltracker.data.api
+
+import com.example.skilltracker.data.dto.CreateSessionRequest
+import com.example.skilltracker.data.dto.SessionDto
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.POST
+import retrofit2.http.Path
+
+interface SessionApi {
+    @GET("api/sessions")
+    suspend fun getSessions(): List<SessionDto>
+
+    @GET("api/sessions/{id}")
+    suspend fun getSession(@Path("id") id: Long): SessionDto
+
+    @POST("api/sessions")
+    suspend fun createSession(@Body request: CreateSessionRequest): SessionDto
+}

--- a/android/app/src/main/java/com/example/skilltracker/data/api/SkillApi.kt
+++ b/android/app/src/main/java/com/example/skilltracker/data/api/SkillApi.kt
@@ -1,0 +1,19 @@
+package com.example.skilltracker.data.api
+
+import com.example.skilltracker.data.dto.CreateSkillRequest
+import com.example.skilltracker.data.dto.SkillDto
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.POST
+import retrofit2.http.Path
+
+interface SkillApi {
+    @GET("api/skills")
+    suspend fun getSkills(): List<SkillDto>
+
+    @GET("api/skills/{id}")
+    suspend fun getSkill(@Path("id") id: Long): SkillDto
+
+    @POST("api/skills")
+    suspend fun createSkill(@Body request: CreateSkillRequest): SkillDto
+}

--- a/android/app/src/main/java/com/example/skilltracker/data/api/StatsApi.kt
+++ b/android/app/src/main/java/com/example/skilltracker/data/api/StatsApi.kt
@@ -1,0 +1,14 @@
+package com.example.skilltracker.data.api
+
+import com.example.skilltracker.data.dto.SkillStatsDto
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+interface StatsApi {
+    @GET("api/stats/skills")
+    suspend fun getSkillStats(
+        @Query("skillId") skillId: Long? = null,
+        @Query("from") from: String? = null,
+        @Query("to") to: String? = null
+    ): List<SkillStatsDto>
+}

--- a/android/app/src/main/java/com/example/skilltracker/data/dto/CreateSessionRequest.kt
+++ b/android/app/src/main/java/com/example/skilltracker/data/dto/CreateSessionRequest.kt
@@ -1,0 +1,8 @@
+package com.example.skilltracker.data.dto
+
+data class CreateSessionRequest(
+    val skillId: Long,
+    val sessionDate: String,
+    val durationMinutes: Int,
+    val notes: String?
+)

--- a/android/app/src/main/java/com/example/skilltracker/data/dto/CreateSkillRequest.kt
+++ b/android/app/src/main/java/com/example/skilltracker/data/dto/CreateSkillRequest.kt
@@ -1,0 +1,6 @@
+package com.example.skilltracker.data.dto
+
+data class CreateSkillRequest(
+    val name: String,
+    val description: String?
+)

--- a/android/app/src/main/java/com/example/skilltracker/data/dto/SessionDto.kt
+++ b/android/app/src/main/java/com/example/skilltracker/data/dto/SessionDto.kt
@@ -1,0 +1,9 @@
+package com.example.skilltracker.data.dto
+
+data class SessionDto(
+    val id: Long,
+    val skillId: Long,
+    val sessionDate: String,
+    val durationMinutes: Int,
+    val notes: String?
+)

--- a/android/app/src/main/java/com/example/skilltracker/data/dto/SkillDto.kt
+++ b/android/app/src/main/java/com/example/skilltracker/data/dto/SkillDto.kt
@@ -1,0 +1,8 @@
+package com.example.skilltracker.data.dto
+
+data class SkillDto(
+    val id: Long,
+    val name: String,
+    val description: String?,
+    val createdAt: String
+)

--- a/android/app/src/main/java/com/example/skilltracker/data/dto/SkillStatsDto.kt
+++ b/android/app/src/main/java/com/example/skilltracker/data/dto/SkillStatsDto.kt
@@ -1,0 +1,8 @@
+package com.example.skilltracker.data.dto
+
+data class SkillStatsDto(
+    val skillId: Long,
+    val skillName: String,
+    val sessionCount: Long,
+    val totalDurationMinutes: Long
+)

--- a/android/app/src/main/java/com/example/skilltracker/data/repository/SessionRepository.kt
+++ b/android/app/src/main/java/com/example/skilltracker/data/repository/SessionRepository.kt
@@ -1,0 +1,25 @@
+package com.example.skilltracker.data.repository
+
+import com.example.skilltracker.data.api.ApiClient
+import com.example.skilltracker.data.dto.CreateSessionRequest
+import com.example.skilltracker.domain.model.Session
+import java.time.Instant
+
+class SessionRepository {
+    private val api = ApiClient.sessionApi
+
+    suspend fun getSessions(): List<Session> = api.getSessions().map { dto ->
+        Session(dto.id, dto.skillId, dto.sessionDate, dto.durationMinutes, dto.notes)
+    }
+
+    suspend fun createSession(skillId: Long, durationMinutes: Int, notes: String?): Session {
+        val request = CreateSessionRequest(
+            skillId = skillId,
+            sessionDate = Instant.now().toString(),
+            durationMinutes = durationMinutes,
+            notes = notes
+        )
+        val dto = api.createSession(request)
+        return Session(dto.id, dto.skillId, dto.sessionDate, dto.durationMinutes, dto.notes)
+    }
+}

--- a/android/app/src/main/java/com/example/skilltracker/data/repository/SkillRepository.kt
+++ b/android/app/src/main/java/com/example/skilltracker/data/repository/SkillRepository.kt
@@ -1,0 +1,23 @@
+package com.example.skilltracker.data.repository
+
+import com.example.skilltracker.data.api.ApiClient
+import com.example.skilltracker.data.dto.CreateSkillRequest
+import com.example.skilltracker.domain.model.Skill
+
+class SkillRepository {
+    private val api = ApiClient.skillApi
+
+    suspend fun getSkills(): List<Skill> = api.getSkills().map { dto ->
+        Skill(
+            id = dto.id,
+            name = dto.name,
+            description = dto.description,
+            createdAt = dto.createdAt
+        )
+    }
+
+    suspend fun createSkill(name: String, description: String?): Skill {
+        val dto = api.createSkill(CreateSkillRequest(name, description))
+        return Skill(dto.id, dto.name, dto.description, dto.createdAt)
+    }
+}

--- a/android/app/src/main/java/com/example/skilltracker/data/repository/StatsRepository.kt
+++ b/android/app/src/main/java/com/example/skilltracker/data/repository/StatsRepository.kt
@@ -1,0 +1,12 @@
+package com.example.skilltracker.data.repository
+
+import com.example.skilltracker.data.api.ApiClient
+import com.example.skilltracker.domain.model.SkillStats
+
+class StatsRepository {
+    private val api = ApiClient.statsApi
+
+    suspend fun getSkillStats(): List<SkillStats> = api.getSkillStats().map { dto ->
+        SkillStats(dto.skillId, dto.skillName, dto.sessionCount, dto.totalDurationMinutes)
+    }
+}

--- a/android/app/src/main/java/com/example/skilltracker/domain/model/Session.kt
+++ b/android/app/src/main/java/com/example/skilltracker/domain/model/Session.kt
@@ -1,0 +1,9 @@
+package com.example.skilltracker.domain.model
+
+data class Session(
+    val id: Long,
+    val skillId: Long,
+    val sessionDate: String,
+    val durationMinutes: Int,
+    val notes: String?
+)

--- a/android/app/src/main/java/com/example/skilltracker/domain/model/Skill.kt
+++ b/android/app/src/main/java/com/example/skilltracker/domain/model/Skill.kt
@@ -1,0 +1,8 @@
+package com.example.skilltracker.domain.model
+
+data class Skill(
+    val id: Long,
+    val name: String,
+    val description: String?,
+    val createdAt: String
+)

--- a/android/app/src/main/java/com/example/skilltracker/domain/model/SkillStats.kt
+++ b/android/app/src/main/java/com/example/skilltracker/domain/model/SkillStats.kt
@@ -1,0 +1,8 @@
+package com.example.skilltracker.domain.model
+
+data class SkillStats(
+    val skillId: Long,
+    val skillName: String,
+    val sessionCount: Long,
+    val totalDurationMinutes: Long
+)

--- a/android/app/src/main/java/com/example/skilltracker/ui/sessions/SessionCreateFragment.kt
+++ b/android/app/src/main/java/com/example/skilltracker/ui/sessions/SessionCreateFragment.kt
@@ -1,0 +1,60 @@
+package com.example.skilltracker.ui.sessions
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Toast
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import com.example.skilltracker.databinding.FragmentSessionCreateBinding
+
+class SessionCreateFragment : Fragment() {
+
+    private var _binding: FragmentSessionCreateBinding? = null
+    private val binding get() = _binding!!
+    private val viewModel: SessionCreateViewModel by viewModels()
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentSessionCreateBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        binding.saveSessionButton.setOnClickListener {
+            val skillId = binding.sessionSkillIdInput.text?.toString()?.toLongOrNull()
+            val duration = binding.sessionDurationInput.text?.toString()?.toIntOrNull()
+            val notes = binding.sessionNotesInput.text?.toString()
+            if (skillId != null && duration != null) {
+                viewModel.createSession(skillId, duration, notes)
+            } else {
+                Toast.makeText(requireContext(), "Invalid input", Toast.LENGTH_SHORT).show()
+            }
+        }
+
+        viewModel.isSuccess.observe(viewLifecycleOwner) { success ->
+            when (success) {
+                true -> {
+                    Toast.makeText(requireContext(), "Session created", Toast.LENGTH_SHORT).show()
+                    viewModel.resetState()
+                }
+                false -> {
+                    Toast.makeText(requireContext(), "Failed to create session", Toast.LENGTH_SHORT).show()
+                    viewModel.resetState()
+                }
+                null -> Unit
+            }
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/android/app/src/main/java/com/example/skilltracker/ui/sessions/SessionCreateViewModel.kt
+++ b/android/app/src/main/java/com/example/skilltracker/ui/sessions/SessionCreateViewModel.kt
@@ -1,0 +1,33 @@
+package com.example.skilltracker.ui.sessions
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.skilltracker.data.repository.SessionRepository
+import kotlinx.coroutines.launch
+
+class SessionCreateViewModel(
+    private val repository: SessionRepository = SessionRepository()
+) : ViewModel() {
+
+    private val _isSaving = MutableLiveData(false)
+    val isSaving: LiveData<Boolean> = _isSaving
+
+    private val _isSuccess = MutableLiveData<Boolean?>(null)
+    val isSuccess: LiveData<Boolean?> = _isSuccess
+
+    fun createSession(skillId: Long, durationMinutes: Int, notes: String?) {
+        viewModelScope.launch {
+            _isSaving.value = true
+            runCatching { repository.createSession(skillId, durationMinutes, notes) }
+                .onSuccess { _isSuccess.value = true }
+                .onFailure { _isSuccess.value = false }
+            _isSaving.value = false
+        }
+    }
+
+    fun resetState() {
+        _isSuccess.value = null
+    }
+}

--- a/android/app/src/main/java/com/example/skilltracker/ui/skills/SkillCreateFragment.kt
+++ b/android/app/src/main/java/com/example/skilltracker/ui/skills/SkillCreateFragment.kt
@@ -1,0 +1,55 @@
+package com.example.skilltracker.ui.skills
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Toast
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import com.example.skilltracker.databinding.FragmentSkillCreateBinding
+
+class SkillCreateFragment : Fragment() {
+
+    private var _binding: FragmentSkillCreateBinding? = null
+    private val binding get() = _binding!!
+    private val viewModel: SkillCreateViewModel by viewModels()
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentSkillCreateBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        binding.saveSkillButton.setOnClickListener {
+            val name = binding.skillNameInput.text?.toString().orEmpty()
+            val description = binding.skillDescriptionInput.text?.toString()
+            viewModel.createSkill(name, description)
+        }
+
+        viewModel.isSuccess.observe(viewLifecycleOwner) { isSuccess ->
+            when (isSuccess) {
+                true -> {
+                    Toast.makeText(requireContext(), "Skill created", Toast.LENGTH_SHORT).show()
+                    viewModel.resetState()
+                }
+                false -> {
+                    Toast.makeText(requireContext(), "Failed to create skill", Toast.LENGTH_SHORT).show()
+                    viewModel.resetState()
+                }
+                null -> Unit
+            }
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/android/app/src/main/java/com/example/skilltracker/ui/skills/SkillCreateViewModel.kt
+++ b/android/app/src/main/java/com/example/skilltracker/ui/skills/SkillCreateViewModel.kt
@@ -1,0 +1,33 @@
+package com.example.skilltracker.ui.skills
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.skilltracker.data.repository.SkillRepository
+import kotlinx.coroutines.launch
+
+class SkillCreateViewModel(
+    private val repository: SkillRepository = SkillRepository()
+) : ViewModel() {
+
+    private val _isSaving = MutableLiveData(false)
+    val isSaving: LiveData<Boolean> = _isSaving
+
+    private val _isSuccess = MutableLiveData<Boolean?>(null)
+    val isSuccess: LiveData<Boolean?> = _isSuccess
+
+    fun createSkill(name: String, description: String?) {
+        viewModelScope.launch {
+            _isSaving.value = true
+            runCatching { repository.createSkill(name, description) }
+                .onSuccess { _isSuccess.value = true }
+                .onFailure { _isSuccess.value = false }
+            _isSaving.value = false
+        }
+    }
+
+    fun resetState() {
+        _isSuccess.value = null
+    }
+}

--- a/android/app/src/main/java/com/example/skilltracker/ui/skills/SkillsAdapter.kt
+++ b/android/app/src/main/java/com/example/skilltracker/ui/skills/SkillsAdapter.kt
@@ -1,0 +1,41 @@
+package com.example.skilltracker.ui.skills
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
+import com.example.skilltracker.R
+import com.example.skilltracker.domain.model.Skill
+
+class SkillsAdapter : RecyclerView.Adapter<SkillsAdapter.SkillViewHolder>() {
+
+    private val items = mutableListOf<Skill>()
+
+    fun submitList(skills: List<Skill>) {
+        items.clear()
+        items.addAll(skills)
+        notifyDataSetChanged()
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): SkillViewHolder {
+        val view = LayoutInflater.from(parent.context).inflate(R.layout.item_skill, parent, false)
+        return SkillViewHolder(view)
+    }
+
+    override fun getItemCount(): Int = items.size
+
+    override fun onBindViewHolder(holder: SkillViewHolder, position: Int) {
+        holder.bind(items[position])
+    }
+
+    class SkillViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+        private val title: TextView = itemView.findViewById(R.id.skillTitle)
+        private val description: TextView = itemView.findViewById(R.id.skillDescription)
+
+        fun bind(skill: Skill) {
+            title.text = skill.name
+            description.text = skill.description ?: ""
+        }
+    }
+}

--- a/android/app/src/main/java/com/example/skilltracker/ui/skills/SkillsListFragment.kt
+++ b/android/app/src/main/java/com/example/skilltracker/ui/skills/SkillsListFragment.kt
@@ -1,0 +1,56 @@
+package com.example.skilltracker.ui.skills
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.example.skilltracker.R
+import com.example.skilltracker.databinding.FragmentSkillsListBinding
+
+class SkillsListFragment : Fragment() {
+
+    private var _binding: FragmentSkillsListBinding? = null
+    private val binding get() = _binding!!
+    private val viewModel: SkillsListViewModel by viewModels()
+    private val adapter = SkillsAdapter()
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentSkillsListBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        binding.skillsRecyclerView.layoutManager = LinearLayoutManager(requireContext())
+        binding.skillsRecyclerView.adapter = adapter
+
+        binding.addSkillButton.setOnClickListener {
+            findNavController().navigate(R.id.action_skillsListFragment_to_skillCreateFragment)
+        }
+
+        binding.addSessionButton.setOnClickListener {
+            findNavController().navigate(R.id.action_skillsListFragment_to_sessionCreateFragment)
+        }
+
+        binding.viewStatsButton.setOnClickListener {
+            findNavController().navigate(R.id.action_skillsListFragment_to_statsFragment)
+        }
+
+        viewModel.skills.observe(viewLifecycleOwner) { skills ->
+            adapter.submitList(skills)
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/android/app/src/main/java/com/example/skilltracker/ui/skills/SkillsListViewModel.kt
+++ b/android/app/src/main/java/com/example/skilltracker/ui/skills/SkillsListViewModel.kt
@@ -1,0 +1,34 @@
+package com.example.skilltracker.ui.skills
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.skilltracker.data.repository.SkillRepository
+import com.example.skilltracker.domain.model.Skill
+import kotlinx.coroutines.launch
+
+class SkillsListViewModel(
+    private val repository: SkillRepository = SkillRepository()
+) : ViewModel() {
+
+    private val _skills = MutableLiveData<List<Skill>>(emptyList())
+    val skills: LiveData<List<Skill>> = _skills
+
+    private val _isLoading = MutableLiveData(false)
+    val isLoading: LiveData<Boolean> = _isLoading
+
+    init {
+        loadSkills()
+    }
+
+    fun loadSkills() {
+        viewModelScope.launch {
+            _isLoading.value = true
+            runCatching { repository.getSkills() }
+                .onSuccess { _skills.value = it }
+                .onFailure { _skills.value = emptyList() }
+            _isLoading.value = false
+        }
+    }
+}

--- a/android/app/src/main/java/com/example/skilltracker/ui/stats/StatsAdapter.kt
+++ b/android/app/src/main/java/com/example/skilltracker/ui/stats/StatsAdapter.kt
@@ -1,0 +1,43 @@
+package com.example.skilltracker.ui.stats
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
+import com.example.skilltracker.R
+import com.example.skilltracker.domain.model.SkillStats
+
+class StatsAdapter : RecyclerView.Adapter<StatsAdapter.StatsViewHolder>() {
+
+    private val items = mutableListOf<SkillStats>()
+
+    fun submitList(stats: List<SkillStats>) {
+        items.clear()
+        items.addAll(stats)
+        notifyDataSetChanged()
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): StatsViewHolder {
+        val view = LayoutInflater.from(parent.context).inflate(R.layout.item_stat, parent, false)
+        return StatsViewHolder(view)
+    }
+
+    override fun getItemCount(): Int = items.size
+
+    override fun onBindViewHolder(holder: StatsViewHolder, position: Int) {
+        holder.bind(items[position])
+    }
+
+    class StatsViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+        private val title: TextView = itemView.findViewById(R.id.statSkillName)
+        private val sessions: TextView = itemView.findViewById(R.id.statSessionCount)
+        private val duration: TextView = itemView.findViewById(R.id.statDuration)
+
+        fun bind(stat: SkillStats) {
+            title.text = stat.skillName
+            sessions.text = "Sessions: ${stat.sessionCount}"
+            duration.text = "Minutes: ${stat.totalDurationMinutes}"
+        }
+    }
+}

--- a/android/app/src/main/java/com/example/skilltracker/ui/stats/StatsFragment.kt
+++ b/android/app/src/main/java/com/example/skilltracker/ui/stats/StatsFragment.kt
@@ -1,0 +1,43 @@
+package com.example.skilltracker.ui.stats
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.example.skilltracker.databinding.FragmentStatsBinding
+
+class StatsFragment : Fragment() {
+
+    private var _binding: FragmentStatsBinding? = null
+    private val binding get() = _binding!!
+    private val viewModel: StatsViewModel by viewModels()
+    private val adapter = StatsAdapter()
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentStatsBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        binding.statsRecyclerView.layoutManager = LinearLayoutManager(requireContext())
+        binding.statsRecyclerView.adapter = adapter
+
+        viewModel.stats.observe(viewLifecycleOwner) { stats ->
+            adapter.submitList(stats)
+        }
+        viewModel.loadStats()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/android/app/src/main/java/com/example/skilltracker/ui/stats/StatsViewModel.kt
+++ b/android/app/src/main/java/com/example/skilltracker/ui/stats/StatsViewModel.kt
@@ -1,0 +1,25 @@
+package com.example.skilltracker.ui.stats
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.skilltracker.data.repository.StatsRepository
+import com.example.skilltracker.domain.model.SkillStats
+import kotlinx.coroutines.launch
+
+class StatsViewModel(
+    private val repository: StatsRepository = StatsRepository()
+) : ViewModel() {
+
+    private val _stats = MutableLiveData<List<SkillStats>>(emptyList())
+    val stats: LiveData<List<SkillStats>> = _stats
+
+    fun loadStats() {
+        viewModelScope.launch {
+            runCatching { repository.getSkillStats() }
+                .onSuccess { _stats.value = it }
+                .onFailure { _stats.value = emptyList() }
+        }
+    }
+}

--- a/android/app/src/main/res/layout/activity_main.xml
+++ b/android/app/src/main/res/layout/activity_main.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <fragment
+        android:id="@+id/nav_host_fragment"
+        android:name="androidx.navigation.fragment.NavHostFragment"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:defaultNavHost="true"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:navGraph="@navigation/nav_graph" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/android/app/src/main/res/layout/fragment_session_create.xml
+++ b/android/app/src/main/res/layout/fragment_session_create.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="16dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <EditText
+            android:id="@+id/sessionSkillIdInput"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="Skill ID"
+            android:inputType="number" />
+
+        <EditText
+            android:id="@+id/sessionDurationInput"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="Duration (minutes)"
+            android:inputType="number"
+            android:layout_marginTop="8dp" />
+
+        <EditText
+            android:id="@+id/sessionNotesInput"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="Notes"
+            android:layout_marginTop="8dp" />
+
+        <Button
+            android:id="@+id/saveSessionButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Save"
+            android:layout_marginTop="16dp" />
+    </LinearLayout>
+</ScrollView>

--- a/android/app/src/main/res/layout/fragment_skill_create.xml
+++ b/android/app/src/main/res/layout/fragment_skill_create.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="16dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <EditText
+            android:id="@+id/skillNameInput"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="Skill name" />
+
+        <EditText
+            android:id="@+id/skillDescriptionInput"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="Description"
+            android:layout_marginTop="8dp" />
+
+        <Button
+            android:id="@+id/saveSkillButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Save"
+            android:layout_marginTop="16dp" />
+    </LinearLayout>
+</ScrollView>

--- a/android/app/src/main/res/layout/fragment_skills_list.xml
+++ b/android/app/src/main/res/layout/fragment_skills_list.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="end"
+        android:layout_marginBottom="8dp">
+
+        <Button
+            android:id="@+id/addSkillButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/add_skill" />
+
+        <Button
+            android:id="@+id/addSessionButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/create_session"
+            android:layout_marginStart="8dp" />
+
+        <Button
+            android:id="@+id/viewStatsButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/stats_title"
+            android:layout_marginStart="8dp" />
+    </LinearLayout>
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/skillsRecyclerView"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1" />
+
+</LinearLayout>

--- a/android/app/src/main/res/layout/fragment_stats.xml
+++ b/android/app/src/main/res/layout/fragment_stats.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/statsRecyclerView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+</LinearLayout>

--- a/android/app/src/main/res/layout/item_skill.xml
+++ b/android/app/src/main/res/layout/item_skill.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <TextView
+        android:id="@+id/skillTitle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textStyle="bold"
+        android:textSize="16sp" />
+
+    <TextView
+        android:id="@+id/skillDescription"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textSize="14sp" />
+
+</LinearLayout>

--- a/android/app/src/main/res/layout/item_stat.xml
+++ b/android/app/src/main/res/layout/item_stat.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <TextView
+        android:id="@+id/statSkillName"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textStyle="bold"
+        android:textSize="16sp" />
+
+    <TextView
+        android:id="@+id/statSessionCount"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="4dp" />
+
+    <TextView
+        android:id="@+id/statDuration"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="4dp" />
+
+</LinearLayout>

--- a/android/app/src/main/res/navigation/nav_graph.xml
+++ b/android/app/src/main/res/navigation/nav_graph.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/nav_graph"
+    app:startDestination="@id/skillsListFragment">
+
+    <fragment
+        android:id="@+id/skillsListFragment"
+        android:name="com.example.skilltracker.ui.skills.SkillsListFragment"
+        android:label="@string/skills_title">
+        <action
+            android:id="@+id/action_skillsListFragment_to_skillCreateFragment"
+            app:destination="@id/skillCreateFragment" />
+        <action
+            android:id="@+id/action_skillsListFragment_to_sessionCreateFragment"
+            app:destination="@id/sessionCreateFragment" />
+        <action
+            android:id="@+id/action_skillsListFragment_to_statsFragment"
+            app:destination="@id/statsFragment" />
+    </fragment>
+
+    <fragment
+        android:id="@+id/skillCreateFragment"
+        android:name="com.example.skilltracker.ui.skills.SkillCreateFragment"
+        android:label="@string/add_skill" />
+
+    <fragment
+        android:id="@+id/sessionCreateFragment"
+        android:name="com.example.skilltracker.ui.sessions.SessionCreateFragment"
+        android:label="@string/create_session" />
+
+    <fragment
+        android:id="@+id/statsFragment"
+        android:name="com.example.skilltracker.ui.stats.StatsFragment"
+        android:label="@string/stats_title" />
+</navigation>

--- a/android/app/src/main/res/values-night/themes.xml
+++ b/android/app/src/main/res/values-night/themes.xml
@@ -1,0 +1,3 @@
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <style name="Theme.SkillTracker" parent="Theme.MaterialComponents.DayNight.NoActionBar" />
+</resources>

--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -1,0 +1,5 @@
+<resources>
+    <color name="purple_500">#6200EE</color>
+    <color name="purple_700">#3700B3</color>
+    <color name="teal_200">#03DAC5</color>
+</resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,0 +1,7 @@
+<resources>
+    <string name="app_name">Skill Tracker</string>
+    <string name="skills_title">Skills</string>
+    <string name="add_skill">Add Skill</string>
+    <string name="create_session">Create Session</string>
+    <string name="stats_title">Stats</string>
+</resources>

--- a/android/app/src/main/res/values/themes.xml
+++ b/android/app/src/main/res/values/themes.xml
@@ -1,0 +1,7 @@
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <style name="Theme.SkillTracker" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+        <item name="colorPrimary">@color/purple_500</item>
+        <item name="colorPrimaryVariant">@color/purple_700</item>
+        <item name="colorAccent">@color/teal_200</item>
+    </style>
+</resources>

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -1,0 +1,4 @@
+plugins {
+    id("com.android.application") version "8.3.2" apply false
+    id("org.jetbrains.kotlin.android") version "1.9.23" apply false
+}

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,0 +1,4 @@
+org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+android.useAndroidX=true
+android.enableJetifier=true
+kotlin.code.style=official

--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -1,0 +1,2 @@
+rootProject.name = "SkillTrackerAndroid"
+include(":app")

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -1,0 +1,31 @@
+plugins {
+    id 'org.springframework.boot' version '3.2.5'
+    id 'io.spring.dependency-management' version '1.1.4'
+    id 'java'
+}
+
+group = 'com.example'
+version = '0.0.1-SNAPSHOT'
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    runtimeOnly 'com.h2database:h2'
+    runtimeOnly 'org.postgresql:postgresql'
+
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+}
+
+tasks.named('test') {
+    useJUnitPlatform()
+}

--- a/backend/settings.gradle
+++ b/backend/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'skilltracker-backend'

--- a/backend/src/main/java/com/example/skilltracker/SkillTrackerApplication.java
+++ b/backend/src/main/java/com/example/skilltracker/SkillTrackerApplication.java
@@ -1,0 +1,12 @@
+package com.example.skilltracker;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class SkillTrackerApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(SkillTrackerApplication.class, args);
+    }
+}

--- a/backend/src/main/java/com/example/skilltracker/common/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/example/skilltracker/common/GlobalExceptionHandler.java
@@ -1,0 +1,46 @@
+package com.example.skilltracker.common;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(ResourceNotFoundException.class)
+    public ResponseEntity<Map<String, Object>> handleNotFound(ResourceNotFoundException ex) {
+        return buildResponse(HttpStatus.NOT_FOUND, ex.getMessage());
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Map<String, Object>> handleValidation(MethodArgumentNotValidException ex) {
+        Map<String, Object> body = new HashMap<>();
+        body.put("timestamp", Instant.now());
+        body.put("status", HttpStatus.BAD_REQUEST.value());
+        body.put("error", "Validation failed");
+        body.put("message", ex.getBindingResult().getAllErrors().stream()
+                .map(error -> error.getDefaultMessage() != null ? error.getDefaultMessage() : error.toString())
+                .toList());
+        return ResponseEntity.badRequest().body(body);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<Map<String, Object>> handleGeneric(Exception ex) {
+        return buildResponse(HttpStatus.INTERNAL_SERVER_ERROR, ex.getMessage());
+    }
+
+    private ResponseEntity<Map<String, Object>> buildResponse(HttpStatus status, String message) {
+        Map<String, Object> body = new HashMap<>();
+        body.put("timestamp", Instant.now());
+        body.put("status", status.value());
+        body.put("error", status.getReasonPhrase());
+        body.put("message", message);
+        return ResponseEntity.status(status).body(body);
+    }
+}

--- a/backend/src/main/java/com/example/skilltracker/common/ResourceNotFoundException.java
+++ b/backend/src/main/java/com/example/skilltracker/common/ResourceNotFoundException.java
@@ -1,0 +1,7 @@
+package com.example.skilltracker.common;
+
+public class ResourceNotFoundException extends RuntimeException {
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/example/skilltracker/session/CreateSessionRequest.java
+++ b/backend/src/main/java/com/example/skilltracker/session/CreateSessionRequest.java
@@ -1,0 +1,12 @@
+package com.example.skilltracker.session;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.Instant;
+
+public record CreateSessionRequest(@NotNull(message = "Skill id is required") Long skillId,
+                                   @NotNull(message = "Session date is required") Instant sessionDate,
+                                   @Min(value = 1, message = "Duration should be at least 1") int durationMinutes,
+                                   String notes) {
+}

--- a/backend/src/main/java/com/example/skilltracker/session/SessionController.java
+++ b/backend/src/main/java/com/example/skilltracker/session/SessionController.java
@@ -1,0 +1,39 @@
+package com.example.skilltracker.session;
+
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/sessions")
+public class SessionController {
+
+    private final SessionService sessionService;
+
+    public SessionController(SessionService sessionService) {
+        this.sessionService = sessionService;
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public SessionDto create(@Valid @RequestBody CreateSessionRequest request) {
+        return sessionService.createSession(request);
+    }
+
+    @GetMapping
+    public List<SessionDto> getAll() {
+        return sessionService.getAll();
+    }
+
+    @GetMapping("/{id}")
+    public SessionDto get(@PathVariable Long id) {
+        return sessionService.getSession(id);
+    }
+
+    @GetMapping("/skill/{skillId}")
+    public List<SessionDto> getBySkill(@PathVariable Long skillId) {
+        return sessionService.findBySkill(skillId);
+    }
+}

--- a/backend/src/main/java/com/example/skilltracker/session/SessionDto.java
+++ b/backend/src/main/java/com/example/skilltracker/session/SessionDto.java
@@ -1,0 +1,6 @@
+package com.example.skilltracker.session;
+
+import java.time.Instant;
+
+public record SessionDto(Long id, Long skillId, Instant sessionDate, int durationMinutes, String notes) {
+}

--- a/backend/src/main/java/com/example/skilltracker/session/SessionEntity.java
+++ b/backend/src/main/java/com/example/skilltracker/session/SessionEntity.java
@@ -1,0 +1,79 @@
+package com.example.skilltracker.session;
+
+import com.example.skilltracker.skill.SkillEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "sessions")
+public class SessionEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "skill_id", nullable = false)
+    private SkillEntity skill;
+
+    @NotNull(message = "Session date is required")
+    @Column(nullable = false)
+    private Instant sessionDate;
+
+    @Min(value = 1, message = "Duration should be at least 1 minute")
+    @Column(nullable = false)
+    private int durationMinutes;
+
+    private String notes;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public SkillEntity getSkill() {
+        return skill;
+    }
+
+    public void setSkill(SkillEntity skill) {
+        this.skill = skill;
+    }
+
+    public Instant getSessionDate() {
+        return sessionDate;
+    }
+
+    public void setSessionDate(Instant sessionDate) {
+        this.sessionDate = sessionDate;
+    }
+
+    public int getDurationMinutes() {
+        return durationMinutes;
+    }
+
+    public void setDurationMinutes(int durationMinutes) {
+        this.durationMinutes = durationMinutes;
+    }
+
+    public String getNotes() {
+        return notes;
+    }
+
+    public void setNotes(String notes) {
+        this.notes = notes;
+    }
+}

--- a/backend/src/main/java/com/example/skilltracker/session/SessionMapper.java
+++ b/backend/src/main/java/com/example/skilltracker/session/SessionMapper.java
@@ -1,0 +1,11 @@
+package com.example.skilltracker.session;
+
+public class SessionMapper {
+
+    private SessionMapper() {
+    }
+
+    public static SessionDto toDto(SessionEntity entity) {
+        return new SessionDto(entity.getId(), entity.getSkill().getId(), entity.getSessionDate(), entity.getDurationMinutes(), entity.getNotes());
+    }
+}

--- a/backend/src/main/java/com/example/skilltracker/session/SessionRepository.java
+++ b/backend/src/main/java/com/example/skilltracker/session/SessionRepository.java
@@ -1,0 +1,18 @@
+package com.example.skilltracker.session;
+
+import com.example.skilltracker.skill.SkillEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.Instant;
+import java.util.List;
+
+public interface SessionRepository extends JpaRepository<SessionEntity, Long> {
+    List<SessionEntity> findBySkill(SkillEntity skill);
+
+    @Query("SELECT s.skill.id, COUNT(s), SUM(s.durationMinutes) FROM SessionEntity s WHERE (:skillId IS NULL OR s.skill.id = :skillId) AND (:fromDate IS NULL OR s.sessionDate >= :fromDate) AND (:toDate IS NULL OR s.sessionDate <= :toDate) GROUP BY s.skill.id")
+    List<Object[]> aggregateBySkill(@Param("skillId") Long skillId,
+                                    @Param("fromDate") Instant fromDate,
+                                    @Param("toDate") Instant toDate);
+}

--- a/backend/src/main/java/com/example/skilltracker/session/SessionService.java
+++ b/backend/src/main/java/com/example/skilltracker/session/SessionService.java
@@ -1,0 +1,54 @@
+package com.example.skilltracker.session;
+
+import com.example.skilltracker.common.ResourceNotFoundException;
+import com.example.skilltracker.skill.SkillEntity;
+import com.example.skilltracker.skill.SkillService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional
+public class SessionService {
+
+    private final SessionRepository sessionRepository;
+    private final SkillService skillService;
+
+    public SessionService(SessionRepository sessionRepository, SkillService skillService) {
+        this.sessionRepository = sessionRepository;
+        this.skillService = skillService;
+    }
+
+    public SessionDto createSession(CreateSessionRequest request) {
+        SkillEntity skill = skillService.findSkill(request.skillId());
+        SessionEntity entity = new SessionEntity();
+        entity.setSkill(skill);
+        entity.setSessionDate(request.sessionDate());
+        entity.setDurationMinutes(request.durationMinutes());
+        entity.setNotes(request.notes());
+        SessionEntity saved = sessionRepository.save(entity);
+        return SessionMapper.toDto(saved);
+    }
+
+    @Transactional(readOnly = true)
+    public List<SessionDto> findBySkill(Long skillId) {
+        SkillEntity skill = skillService.findSkill(skillId);
+        return sessionRepository.findBySkill(skill).stream()
+                .map(SessionMapper::toDto)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public SessionDto getSession(Long id) {
+        return SessionMapper.toDto(sessionRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Session %d not found".formatted(id))));
+    }
+
+    @Transactional(readOnly = true)
+    public List<SessionDto> getAll() {
+        return sessionRepository.findAll().stream()
+                .map(SessionMapper::toDto)
+                .toList();
+    }
+}

--- a/backend/src/main/java/com/example/skilltracker/skill/CreateSkillRequest.java
+++ b/backend/src/main/java/com/example/skilltracker/skill/CreateSkillRequest.java
@@ -1,0 +1,7 @@
+package com.example.skilltracker.skill;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record CreateSkillRequest(@NotBlank(message = "Name is required") String name,
+                                 String description) {
+}

--- a/backend/src/main/java/com/example/skilltracker/skill/SkillController.java
+++ b/backend/src/main/java/com/example/skilltracker/skill/SkillController.java
@@ -1,0 +1,45 @@
+package com.example.skilltracker.skill;
+
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/skills")
+public class SkillController {
+
+    private final SkillService skillService;
+
+    public SkillController(SkillService skillService) {
+        this.skillService = skillService;
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public SkillDto create(@Valid @RequestBody CreateSkillRequest request) {
+        return skillService.createSkill(request);
+    }
+
+    @GetMapping
+    public List<SkillDto> getAll() {
+        return skillService.getAllSkills();
+    }
+
+    @GetMapping("/{id}")
+    public SkillDto get(@PathVariable Long id) {
+        return skillService.getSkill(id);
+    }
+
+    @PutMapping("/{id}")
+    public SkillDto update(@PathVariable Long id, @Valid @RequestBody UpdateSkillRequest request) {
+        return skillService.updateSkill(id, request);
+    }
+
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(@PathVariable Long id) {
+        skillService.deleteSkill(id);
+    }
+}

--- a/backend/src/main/java/com/example/skilltracker/skill/SkillDto.java
+++ b/backend/src/main/java/com/example/skilltracker/skill/SkillDto.java
@@ -1,0 +1,6 @@
+package com.example.skilltracker.skill;
+
+import java.time.Instant;
+
+public record SkillDto(Long id, String name, String description, Instant createdAt) {
+}

--- a/backend/src/main/java/com/example/skilltracker/skill/SkillEntity.java
+++ b/backend/src/main/java/com/example/skilltracker/skill/SkillEntity.java
@@ -1,0 +1,61 @@
+package com.example.skilltracker.skill;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotBlank;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "skills")
+public class SkillEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotBlank(message = "Skill name is required")
+    @Column(nullable = false, unique = true)
+    private String name;
+
+    private String description;
+
+    @Column(nullable = false, updatable = false)
+    private Instant createdAt = Instant.now();
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+}

--- a/backend/src/main/java/com/example/skilltracker/skill/SkillMapper.java
+++ b/backend/src/main/java/com/example/skilltracker/skill/SkillMapper.java
@@ -1,0 +1,16 @@
+package com.example.skilltracker.skill;
+
+public class SkillMapper {
+
+    private SkillMapper() {
+    }
+
+    public static SkillDto toDto(SkillEntity entity) {
+        return new SkillDto(entity.getId(), entity.getName(), entity.getDescription(), entity.getCreatedAt());
+    }
+
+    public static void updateEntity(SkillEntity entity, UpdateSkillRequest request) {
+        entity.setName(request.name());
+        entity.setDescription(request.description());
+    }
+}

--- a/backend/src/main/java/com/example/skilltracker/skill/SkillRepository.java
+++ b/backend/src/main/java/com/example/skilltracker/skill/SkillRepository.java
@@ -1,0 +1,9 @@
+package com.example.skilltracker.skill;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface SkillRepository extends JpaRepository<SkillEntity, Long> {
+    Optional<SkillEntity> findByNameIgnoreCase(String name);
+}

--- a/backend/src/main/java/com/example/skilltracker/skill/SkillService.java
+++ b/backend/src/main/java/com/example/skilltracker/skill/SkillService.java
@@ -1,0 +1,54 @@
+package com.example.skilltracker.skill;
+
+import com.example.skilltracker.common.ResourceNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional
+public class SkillService {
+
+    private final SkillRepository skillRepository;
+
+    public SkillService(SkillRepository skillRepository) {
+        this.skillRepository = skillRepository;
+    }
+
+    public SkillDto createSkill(CreateSkillRequest request) {
+        SkillEntity entity = new SkillEntity();
+        entity.setName(request.name());
+        entity.setDescription(request.description());
+        SkillEntity saved = skillRepository.save(entity);
+        return SkillMapper.toDto(saved);
+    }
+
+    @Transactional(readOnly = true)
+    public List<SkillDto> getAllSkills() {
+        return skillRepository.findAll().stream()
+                .map(SkillMapper::toDto)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public SkillDto getSkill(Long id) {
+        return SkillMapper.toDto(findSkill(id));
+    }
+
+    public SkillDto updateSkill(Long id, UpdateSkillRequest request) {
+        SkillEntity entity = findSkill(id);
+        SkillMapper.updateEntity(entity, request);
+        return SkillMapper.toDto(skillRepository.save(entity));
+    }
+
+    public void deleteSkill(Long id) {
+        SkillEntity entity = findSkill(id);
+        skillRepository.delete(entity);
+    }
+
+    public SkillEntity findSkill(Long id) {
+        return skillRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Skill %d not found".formatted(id)));
+    }
+}

--- a/backend/src/main/java/com/example/skilltracker/skill/UpdateSkillRequest.java
+++ b/backend/src/main/java/com/example/skilltracker/skill/UpdateSkillRequest.java
@@ -1,0 +1,7 @@
+package com.example.skilltracker.skill;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record UpdateSkillRequest(@NotBlank(message = "Name is required") String name,
+                                 String description) {
+}

--- a/backend/src/main/java/com/example/skilltracker/stats/SkillStatsDto.java
+++ b/backend/src/main/java/com/example/skilltracker/stats/SkillStatsDto.java
@@ -1,0 +1,4 @@
+package com.example.skilltracker.stats;
+
+public record SkillStatsDto(Long skillId, String skillName, long sessionCount, long totalDurationMinutes) {
+}

--- a/backend/src/main/java/com/example/skilltracker/stats/StatsController.java
+++ b/backend/src/main/java/com/example/skilltracker/stats/StatsController.java
@@ -1,0 +1,32 @@
+package com.example.skilltracker.stats;
+
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.Instant;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/stats")
+public class StatsController {
+
+    private final StatsService statsService;
+
+    public StatsController(StatsService statsService) {
+        this.statsService = statsService;
+    }
+
+    @GetMapping("/skills")
+    public List<SkillStatsDto> getSkillStats(@RequestParam(required = false) Long skillId,
+                                             @RequestParam(required = false)
+                                             @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+                                             Instant from,
+                                             @RequestParam(required = false)
+                                             @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+                                             Instant to) {
+        return statsService.aggregateSkillStats(skillId, from, to);
+    }
+}

--- a/backend/src/main/java/com/example/skilltracker/stats/StatsService.java
+++ b/backend/src/main/java/com/example/skilltracker/stats/StatsService.java
@@ -1,0 +1,44 @@
+package com.example.skilltracker.stats;
+
+import com.example.skilltracker.skill.SkillEntity;
+import com.example.skilltracker.skill.SkillRepository;
+import com.example.skilltracker.session.SessionRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional(readOnly = true)
+public class StatsService {
+
+    private final SessionRepository sessionRepository;
+    private final SkillRepository skillRepository;
+
+    public StatsService(SessionRepository sessionRepository, SkillRepository skillRepository) {
+        this.sessionRepository = sessionRepository;
+        this.skillRepository = skillRepository;
+    }
+
+    public List<SkillStatsDto> aggregateSkillStats(Long skillId, Instant from, Instant to) {
+        List<Object[]> rawResults = sessionRepository.aggregateBySkill(skillId, from, to);
+        Map<Long, SkillEntity> skillMap = skillRepository.findAll().stream()
+                .collect(Collectors.toMap(SkillEntity::getId, skill -> skill));
+
+        return rawResults.stream()
+                .map(row -> {
+                    Long id = (Long) row[0];
+                    SkillEntity skill = skillMap.get(id);
+                    String name = skill != null ? skill.getName() : ("Skill #" + id);
+                    Long count = (Long) row[1];
+                    Long totalDuration = row[2] != null ? (Long) row[2] : 0L;
+                    return new SkillStatsDto(id, name, count != null ? count : 0L, totalDuration);
+                })
+                .sorted(Comparator.comparing(SkillStatsDto::sessionCount).reversed())
+                .toList();
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,0 +1,43 @@
+spring:
+  application:
+    name: skilltracker
+  datasource:
+    url: jdbc:h2:mem:skilltracker;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    driver-class-name: org.h2.Driver
+    username: sa
+    password: password
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        format_sql: true
+    show-sql: true
+
+---
+spring:
+  config:
+    activate:
+      on-profile: postgres
+  datasource:
+    url: jdbc:postgresql://localhost:5432/skilltracker
+    driver-class-name: org.postgresql.Driver
+    username: skilltracker
+    password: skilltracker
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+
+---
+spring:
+  config:
+    activate:
+      on-profile: h2
+  datasource:
+    url: jdbc:h2:mem:skilltracker;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    driver-class-name: org.h2.Driver
+    username: sa
+    password: password


### PR DESCRIPTION
## Summary
- add a Spring Boot backend with skill and session entities, services, controllers, and stats aggregation
- configure an Android Kotlin app with Retrofit data sources, repositories, view models, and simple navigation-driven UI
- add shared gitignore and Gradle build scripts for both projects

## Testing
- not run (not supported in this environment)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69120ff5cf448333aeb68ecf85175779)