### PR TITLE
Fill missing overview and stats string resources

### DIFF
--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -14,6 +14,16 @@
     <string name="tab_skills">Skills</string>
     <string name="tab_stats">Stats</string>
 
+    <!-- Skill list / overview -->
+    <string name="overview_total_minutes">Total minutes</string>
+    <string name="overview_sessions_count">Sessions</string>
+    <string name="overview_skills_count">Skills</string>
+    <string name="add_skill">Add skill</string>
+    <string name="create_session">Create session</string>
+    <string name="stats_title">Statistics</string>
+    <string name="skills_title">Skills</string>
+    <string name="include_archived">Include archived</string>
+
     <!-- Skill list / item -->
     <string name="skill_item_target">%1$d %2$s</string>
     <string name="skill_item_sessions">%1$d sessions</string>
@@ -55,6 +65,10 @@
     <string name="create_session_title">New session</string>
     <string name="session_create_title">Create session</string>
     <string name="session_edit_title">Edit session</string>
+    <string name="label_session_skill">Skill</string>
+    <string name="label_session_date">Date and time</string>
+    <string name="label_session_value">Result / value</string>
+    <string name="label_session_notes">Notes</string>
     <string name="session_label_skill">Skill</string>
     <string name="session_label_date">Date and time</string>
     <string name="session_label_value">Result / value</string>
@@ -67,18 +81,29 @@
         You can edit this session later in the skill details screen.
     </string>
     <string name="session_delete_button">Delete session</string>
+    <string name="session_skill_label">Skill</string>
+    <string name="session_select_date">Select date</string>
+    <string name="session_select_time">Select time</string>
+    <string name="session_clear_datetime">Clear date &amp; time</string>
+    <string name="session_duration_hint">Duration (minutes)</string>
+    <string name="session_difficulty_placeholder">Difficulty</string>
+    <string name="session_source_label">Session source</string>
+    <string name="save">Save</string>
 
     <!-- Skill create / edit -->
     <string name="create_skill_title">New skill</string>
     <string name="skill_create_title">Create skill</string>
+    <string name="skill_edit_title">Edit skill</string>
 
     <string name="skill_label_name">Skill name</string>
     <string name="label_skill_name">Skill name</string>
     <string name="hint_skill_name">For example: Push-ups, English, Piano practice</string>
+    <string name="skill_name_hint_required">Skill name (required)</string>
 
     <string name="skill_label_description">Description</string>
     <string name="label_skill_description">Description</string>
     <string name="hint_skill_description">Short description of this skill</string>
+    <string name="skill_description_hint">Describe the skill</string>
 
     <string name="skill_type_label">Skill type</string>
     <string name="label_skill_type">Skill type</string>
@@ -109,12 +134,19 @@
     <string name="skill_schedule_additional_info">
         The schedule is only a reminder, you can log sessions on any day.
     </string>
+    <string name="skill_category_hint">Category (optional)</string>
+    <string name="skill_color_hint">Color (e.g., #FF0000)</string>
+    <string name="skill_archive_button">Archive skill</string>
 
     <!-- Session placeholders -->
     <string name="session_date_placeholder">Not selected</string>
     <string name="session_value_placeholder">0</string>
 
     <!-- Stats screen -->
+    <string name="stats_summary_title">Summary</string>
+    <string name="label_total_sessions">Total sessions</string>
+    <string name="label_total_skills">Total skills</string>
+    <string name="label_average_progress">Average progress</string>
     <string name="stats_header_overview">Overview</string>
     <string name="stats_header_today">Today</string>
     <string name="stats_header_last_week">Last week</string>
@@ -135,11 +167,20 @@
     <string name="stats_daily_streak">Current streak</string>
     <string name="stats_streak_days">%1$d days</string>
 
+    <string name="stats_skill_progress_title">Skill progress</string>
+    <string name="label_stats_skill_name">Skill</string>
+    <string name="label_stats_skill_progress">Progress</string>
+    <string name="stats_skill_progress_empty">No progress to show yet</string>
+    <string name="stats_session_list_title">Recent sessions</string>
+
     <string name="stats_today_total_short">%1$d min</string>
     <string name="stats_today_best_short">%1$d min</string>
 
     <!-- Chart / stats misc -->
     <string name="stats_chart_content_description">Statistics chart</string>
+
+    <!-- Misc -->
+    <string name="skill_archived_label">Archived</string>
 
     <!-- Generic messages -->
     <string name="error_general">Something went wrong. Please try again.</string>


### PR DESCRIPTION
## Summary
- add the string resources required by the refreshed skills overview layout
- provide the stats screen labels referenced by the updated statistics UI
- include an archived badge label for skill list items

## Testing
- `cd android && ./gradlew :app:assembleDebug` *(fails: Gradle wrapper lacks execute permission in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916ea938fcc83339442e72672c16799)