### PR TITLE
Handle device backend URL and improve input readability

### DIFF
--- a/android/app/src/main/java/com/example/skilltracker/data/api/ApiClient.kt
+++ b/android/app/src/main/java/com/example/skilltracker/data/api/ApiClient.kt
@@ -1,5 +1,6 @@
 package com.example.skilltracker.data.api
 
+import android.os.Build
 import com.squareup.moshi.Moshi
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
@@ -7,7 +8,11 @@ import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
 
 object ApiClient {
-    private const val BASE_URL = "http://10.0.2.2:8080/"
+    private const val EMULATOR_BASE_URL = "http://10.0.2.2:8080/"
+    private const val DEVICE_BASE_URL = "http://127.0.0.1:8080/"
+
+    private val baseUrl: String
+        get() = if (isRunningOnEmulator()) EMULATOR_BASE_URL else DEVICE_BASE_URL
 
     private val loggingInterceptor = HttpLoggingInterceptor().apply {
         level = HttpLoggingInterceptor.Level.BODY
@@ -18,7 +23,7 @@ object ApiClient {
         .build()
 
     private val retrofit: Retrofit = Retrofit.Builder()
-        .baseUrl(BASE_URL)
+        .baseUrl(baseUrl)
         .client(okHttpClient)
         .addConverterFactory(MoshiConverterFactory.create(Moshi.Builder().build()))
         .build()
@@ -26,4 +31,19 @@ object ApiClient {
     val skillApi: SkillApi = retrofit.create(SkillApi::class.java)
     val sessionApi: SessionApi = retrofit.create(SessionApi::class.java)
     val statsApi: StatsApi = retrofit.create(StatsApi::class.java)
+
+    private fun isRunningOnEmulator(): Boolean {
+        val fingerprint = Build.FINGERPRINT
+        val model = Build.MODEL
+        val brand = Build.BRAND
+        val device = Build.DEVICE
+        return fingerprint.contains("generic", ignoreCase = true) ||
+            fingerprint.contains("emulator", ignoreCase = true) ||
+            model.contains("google_sdk", ignoreCase = true) ||
+            model.contains("droid4x", ignoreCase = true) ||
+            model.contains("emulator", ignoreCase = true) ||
+            model.contains("android sdk built for x86", ignoreCase = true) ||
+            brand.startsWith("generic") && device.startsWith("generic") ||
+            "google_sdk" == Build.PRODUCT
+    }
 }

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -6,6 +6,11 @@
         <item name="android:fontFamily">sans-serif</item>
     </style>
 
+    <style name="Widget.SkillTracker.EditText" parent="@style/Widget.AppCompat.EditText">
+        <item name="android:textColor">@color/colorOnSurface</item>
+        <item name="android:textColorHint">@color/colorOnSurfaceVariant</item>
+    </style>
+
     <style name="TextAppearance.SkillTracker.Headline" parent="TextAppearance.MaterialComponents.Headline6">
         <item name="android:textColor">@color/colorOnBackground</item>
         <item name="android:textSize">22sp</item>

--- a/android/app/src/main/res/values/themes.xml
+++ b/android/app/src/main/res/values/themes.xml
@@ -17,6 +17,7 @@
         <item name="android:windowLightNavigationBar">false</item>
         <item name="materialButtonStyle">@style/Widget.SkillTracker.Button.Primary</item>
         <item name="materialCardViewStyle">@style/Widget.SkillTracker.Card</item>
+        <item name="android:editTextStyle">@style/Widget.SkillTracker.EditText</item>
         <item name="textInputStyle">@style/Widget.SkillTracker.TextInputLayout</item>
         <item name="android:textViewStyle">@style/Widget.SkillTracker.TextView</item>
         <item name="chipStyle">@style/Widget.SkillTracker.Chip</item>


### PR DESCRIPTION
## Summary
- detect whether the app is running on an emulator or a physical device and use the matching backend base URL
- define a shared EditText style so skill/session forms show readable text and hints

## Testing
- ./gradlew :app:lintDebug --console=plain --no-daemon

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916fa63f63083338a41bbddb572069e)