### PR TITLE
Implement MiniTasker backend and Android client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,68 @@
+# MiniTasker Full-Stack Учебный Проект
+
+MiniTasker — учебный full-stack проект, состоящий из backend-сервиса на Spring Boot и Android-клиента на Kotlin/Jetpack Compose. Приложение реализует требования преподавателя: аутентификация по JWT, разграничение ролей, полный CRUD по сущностям проектов/задач, работу с комментариями и вложениями, а также экран статистики.
+
+## Архитектура backend-проекта
+- **Сборка:** Maven (`backend/pom.xml`), Java 17, Spring Boot 3.2.
+- **Слои и пакеты:**
+  - `controller` — REST-контроллеры (`AuthController`, `ProjectController`, `TaskController`, `CommentController`, `AttachmentController`, `StatsController`, `ReportController`).
+  - `service` и `service.impl` — бизнес-логика, проверки прав, логирование ключевых операций.
+  - `repository` — `JpaRepository` для каждой сущности.
+  - `model`/`entity` и `model.enums` — JPA-сущности и перечисления ролей/статусов/приоритетов.
+  - `dto` — DTO для запросов/ответов (auth, проекты, задачи, комментарии, вложения, статистика).
+  - `security` — JWT-фильтр, провайдер токенов, настройка Spring Security.
+  - `exception` — глобальная обработка ошибок и кастомные исключения.
+  - `config`/`util` — конфигурация хранилища файлов и утилиты безопасности.
+- **БД:** PostgreSQL (настройки в `application.yml`, `ddl-auto=update`).
+- **Безопасность:** Spring Security + JWT, BCrypt для паролей, разграничение прав (USER видит только свои данные, ADMIN — все).
+- **Дополнительно:** экспорт CSV, статистика задач, логирование аутентификации/CRUD операций, обработка ошибок через `@ControllerAdvice`.
+
+## Архитектура Android-приложения
+- **Сборка:** Gradle (AGP 8.3.2), Kotlin 1.9, Jetpack Compose.
+- **Пакеты:**
+  - `data/api` — `Retrofit`-интерфейс, `AuthInterceptor`.
+  - `data/model` — модели API и DTO.
+  - `data/local` — `AuthPreferences` на DataStore для хранения JWT.
+  - `data/repository` — репозитории и `ServiceLocator`.
+  - `ui` — экраны, компоненты, навигация.
+  - `MiniTaskerApplication` — точка входа и ленивые singletons репозиториев.
+- **Технологии:** Retrofit+Moshi, OkHttp, Coroutines/Flow, DataStore, Navigation Compose, Material 3, MPAndroidChart для визуализации.
+- **Экраны:**
+  1. Аутентификация/регистрация.
+  2. Список проектов с созданием и выходом.
+  3. Список задач проекта с фильтрами и быстрым созданием.
+  4. Деталь задачи: данные, смена статуса/приоритета, комментарии, вложения с выбором файла.
+  5. Статистика (графики распределения по статусам/приоритетам).
+- **Работа с JWT:** токен хранится в DataStore, `AuthInterceptor` автоматически подставляет заголовок Authorization.
+- **Обработка ошибок:** `safeCall` возвращает `NetworkResult` для отображения сообщений и состояний загрузки.
+
+## Запуск backend
+1. Установите PostgreSQL и создайте БД/пользователя `minitasker`/`minitasker` или измените `backend/src/main/resources/application.yml`.
+2. Соберите и запустите сервис:
+   ```bash
+   cd backend
+   ./mvnw spring-boot:run
+   ```
+   (или `mvn spring-boot:run`, если Maven установлен глобально).
+3. API доступно на `http://localhost:8080`.
+
+## Сборка и запуск Android-клиента
+1. Откройте каталог `android/` в Android Studio (Giraffe+).
+2. Убедитесь, что устройство/эмулятор могут обратиться к backend (`10.0.2.2:8080` для эмулятора, при необходимости измените `ServiceLocator.BASE_URL`).
+3. Запустите сборку/установку через Android Studio или командой:
+   ```bash
+   cd android
+   ./gradlew assembleDebug
+   ```
+
+## Структура репозитория
+```
+backend/  - Spring Boot сервис
+android/  - Android-приложение
+README.md - этот файл
+```
+
+## Дальнейшие шаги
+- Добавить unit- и instrumented-тесты.
+- Настроить CI-пайплайн.
+- Реализовать загрузку файлов в облачное хранилище и предпросмотр вложений в Android.

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,0 +1,88 @@
+plugins {
+    id("com.android.application")
+    id("org.jetbrains.kotlin.android")
+    id("kotlin-kapt")
+}
+
+android {
+    namespace = "com.example.minitasker"
+    compileSdk = 34
+
+    defaultConfig {
+        applicationId = "com.example.minitasker"
+        minSdk = 24
+        targetSdk = 34
+        versionCode = 1
+        versionName = "1.0"
+
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    buildTypes {
+        getByName("release") {
+            isMinifyEnabled = false
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+
+    buildFeatures {
+        compose = true
+    }
+
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.5.11"
+    }
+
+    packaging {
+        resources {
+            excludes += "/META-INF/{AL2.0,LGPL2.1}"
+        }
+    }
+}
+
+dependencies {
+    val composeBom = platform("androidx.compose:compose-bom:2024.02.01")
+
+    implementation(composeBom)
+    androidTestImplementation(composeBom)
+
+    implementation("androidx.core:core-ktx:1.12.0")
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.7.0")
+    implementation("androidx.activity:activity-compose:1.9.0")
+    implementation("androidx.compose.ui:ui")
+    implementation("androidx.compose.ui:ui-tooling-preview")
+    implementation("androidx.compose.material3:material3:1.2.1")
+    debugImplementation("androidx.compose.ui:ui-tooling")
+    debugImplementation("androidx.compose.ui:ui-test-manifest")
+
+    implementation("androidx.navigation:navigation-compose:2.7.7")
+    implementation("androidx.datastore:datastore-preferences:1.0.0")
+
+    implementation("com.squareup.retrofit2:retrofit:2.11.0")
+    implementation("com.squareup.retrofit2:converter-moshi:2.11.0")
+    implementation("com.squareup.okhttp3:logging-interceptor:4.12.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
+
+    implementation("com.github.PhilJay:MPAndroidChart:v3.1.0")
+
+    implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.7.0")
+    implementation("androidx.lifecycle:lifecycle-runtime-compose:2.7.0")
+
+    testImplementation("junit:junit:4.13.2")
+    androidTestImplementation("androidx.test.ext:junit:1.1.5")
+    androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
+    androidTestImplementation("androidx.compose.ui:ui-test-junit4")
+}

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -1,0 +1,3 @@
+# Proguard rules for MiniTasker Android app
+-dontwarn okhttp3.**
+-dontwarn retrofit2.**

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application
+        android:name="com.example.minitasker.MiniTaskerApplication"
+        android:allowBackup="true"
+        android:icon="@android:drawable/sym_def_app_icon"
+        android:label="@string/app_name"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.Material3.DayNight.NoActionBar">
+        <activity
+            android:name="com.example.minitasker.MainActivity"
+            android:exported="true"
+            android:theme="@style/Theme.Material3.DayNight.NoActionBar">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/android/app/src/main/java/com/example/minitasker/MainActivity.kt
+++ b/android/app/src/main/java/com/example/minitasker/MainActivity.kt
@@ -1,0 +1,122 @@
+package com.example.minitasker
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavType
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navArgument
+import com.example.minitasker.ui.navigation.Screen
+import com.example.minitasker.ui.screen.auth.AuthScreen
+import com.example.minitasker.ui.screen.auth.AuthViewModel
+import com.example.minitasker.ui.screen.projects.ProjectsScreen
+import com.example.minitasker.ui.screen.projects.ProjectsViewModel
+import com.example.minitasker.ui.screen.stats.StatsScreen
+import com.example.minitasker.ui.screen.stats.StatsViewModel
+import com.example.minitasker.ui.screen.taskdetail.TaskDetailScreen
+import com.example.minitasker.ui.screen.taskdetail.TaskDetailViewModel
+import com.example.minitasker.ui.screen.tasks.TasksScreen
+import com.example.minitasker.ui.screen.tasks.TasksViewModel
+
+class MainActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val app = application as MiniTaskerApplication
+        setContent {
+            MaterialTheme {
+                Surface(color = MaterialTheme.colorScheme.background) {
+                    MiniTaskerNavHost(app)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun MiniTaskerNavHost(app: MiniTaskerApplication) {
+    val navController = rememberNavController()
+    val authViewModel: AuthViewModel = viewModel(factory = SimpleFactory { AuthViewModel(app.authRepository) })
+    val projectsViewModel: ProjectsViewModel = viewModel(factory = SimpleFactory { ProjectsViewModel(app.projectRepository, app.authRepository) })
+    val tasksViewModel: TasksViewModel = viewModel(factory = SimpleFactory { TasksViewModel(app.taskRepository) })
+    val taskDetailViewModel: TaskDetailViewModel = viewModel(factory = SimpleFactory { TaskDetailViewModel(app.taskRepository) })
+    val statsViewModel: StatsViewModel = viewModel(factory = SimpleFactory { StatsViewModel(app.statsRepository) })
+
+    NavHost(navController = navController, startDestination = Screen.Auth.route) {
+        composable(Screen.Auth.route) {
+            AuthScreen(viewModel = authViewModel) {
+                navController.navigate(Screen.Projects.route) {
+                    popUpTo(Screen.Auth.route) { inclusive = true }
+                }
+            }
+        }
+        composable(Screen.Projects.route) {
+            ProjectsScreen(
+                viewModel = projectsViewModel,
+                onProjectSelected = {
+                    navController.navigate(Screen.Tasks.create(it.id, it.name))
+                },
+                onShowStats = {
+                    navController.navigate(Screen.Stats.create(it.id, it.name))
+                },
+                onLoggedOut = {
+                    authViewModel.reset()
+                    navController.navigate(Screen.Auth.route) {
+                        popUpTo(Screen.Projects.route) { inclusive = true }
+                    }
+                }
+            )
+        }
+        composable(
+            Screen.Tasks.route,
+            arguments = listOf(
+                navArgument("projectId") { type = NavType.LongType },
+                navArgument("projectName") { type = NavType.StringType }
+            )
+        ) { backStackEntry ->
+            val projectId = backStackEntry.arguments?.getLong("projectId") ?: 0L
+            val projectName = backStackEntry.arguments?.getString("projectName") ?: ""
+            TasksScreen(
+                projectId = projectId,
+                projectName = projectName,
+                viewModel = tasksViewModel,
+                onTaskSelected = { taskId ->
+                    navController.navigate(Screen.TaskDetail.create(taskId))
+                }
+            )
+        }
+        composable(
+            Screen.TaskDetail.route,
+            arguments = listOf(navArgument("taskId") { type = NavType.LongType })
+        ) { backStackEntry ->
+            val taskId = backStackEntry.arguments?.getLong("taskId") ?: 0L
+            TaskDetailScreen(taskId = taskId, viewModel = taskDetailViewModel)
+        }
+        composable(
+            Screen.Stats.route,
+            arguments = listOf(
+                navArgument("projectId") { type = NavType.LongType },
+                navArgument("projectName") { type = NavType.StringType }
+            )
+        ) { entry ->
+            val projectId = entry.arguments?.getLong("projectId") ?: 0L
+            val projectName = entry.arguments?.getString("projectName") ?: ""
+            StatsScreen(projectId = projectId, projectName = projectName, viewModel = statsViewModel)
+        }
+    }
+}
+
+class SimpleFactory<T : androidx.lifecycle.ViewModel>(private val creator: () -> T) : androidx.lifecycle.ViewModelProvider.Factory {
+    override fun <T : androidx.lifecycle.ViewModel> create(modelClass: Class<T>): T {
+        return creator.invoke() as T
+    }
+}

--- a/android/app/src/main/java/com/example/minitasker/MiniTaskerApplication.kt
+++ b/android/app/src/main/java/com/example/minitasker/MiniTaskerApplication.kt
@@ -1,0 +1,11 @@
+package com.example.minitasker
+
+import android.app.Application
+import com.example.minitasker.data.repository.ServiceLocator
+
+class MiniTaskerApplication : Application() {
+    val authRepository by lazy { ServiceLocator.provideAuthRepository(this) }
+    val projectRepository by lazy { ServiceLocator.provideProjectRepository(this) }
+    val taskRepository by lazy { ServiceLocator.provideTaskRepository(this) }
+    val statsRepository by lazy { ServiceLocator.provideStatsRepository(this) }
+}

--- a/android/app/src/main/java/com/example/minitasker/data/api/ApiService.kt
+++ b/android/app/src/main/java/com/example/minitasker/data/api/ApiService.kt
@@ -1,0 +1,104 @@
+package com.example.minitasker.data.api
+
+import com.example.minitasker.data.model.AttachmentDto
+import com.example.minitasker.data.model.AuthResponse
+import com.example.minitasker.data.model.CommentDto
+import com.example.minitasker.data.model.CommentRequest
+import com.example.minitasker.data.model.LoginRequest
+import com.example.minitasker.data.model.PagedResponse
+import com.example.minitasker.data.model.ProjectDto
+import com.example.minitasker.data.model.ProjectRequest
+import com.example.minitasker.data.model.RegisterRequest
+import com.example.minitasker.data.model.StatsDto
+import com.example.minitasker.data.model.TaskRequest
+import com.example.minitasker.data.model.TaskResponseDto
+import com.example.minitasker.data.model.TaskSummaryDto
+import com.example.minitasker.data.model.UserDto
+import okhttp3.MultipartBody
+import retrofit2.http.Body
+import retrofit2.http.DELETE
+import retrofit2.http.GET
+import retrofit2.http.Multipart
+import retrofit2.http.POST
+import retrofit2.http.PUT
+import retrofit2.http.Part
+import retrofit2.http.Path
+import retrofit2.http.Query
+
+interface ApiService {
+
+    // Auth
+    @POST("/api/auth/register")
+    suspend fun register(@Body request: RegisterRequest): AuthResponse
+
+    @POST("/api/auth/login")
+    suspend fun login(@Body request: LoginRequest): AuthResponse
+
+    @GET("/api/auth/me")
+    suspend fun currentUser(): UserDto
+
+    // Projects
+    @GET("/api/projects")
+    suspend fun getProjects(
+        @Query("name") name: String?,
+        @Query("page") page: Int,
+        @Query("size") size: Int
+    ): PagedResponse<ProjectDto>
+
+    @POST("/api/projects")
+    suspend fun createProject(@Body request: ProjectRequest): ProjectDto
+
+    @PUT("/api/projects/{id}")
+    suspend fun updateProject(@Path("id") id: Long, @Body request: ProjectRequest): ProjectDto
+
+    @DELETE("/api/projects/{id}")
+    suspend fun deleteProject(@Path("id") id: Long)
+
+    // Tasks
+    @GET("/api/projects/{projectId}/tasks")
+    suspend fun getTasks(
+        @Path("projectId") projectId: Long,
+        @Query("status") status: String?,
+        @Query("priority") priority: String?,
+        @Query("assigneeId") assigneeId: Long?,
+        @Query("page") page: Int,
+        @Query("size") size: Int
+    ): PagedResponse<TaskSummaryDto>
+
+    @POST("/api/projects/{projectId}/tasks")
+    suspend fun createTask(@Path("projectId") projectId: Long, @Body request: TaskRequest): TaskResponseDto
+
+    @GET("/api/tasks/{taskId}")
+    suspend fun getTask(@Path("taskId") taskId: Long): TaskResponseDto
+
+    @PUT("/api/tasks/{taskId}")
+    suspend fun updateTask(@Path("taskId") taskId: Long, @Body request: TaskRequest): TaskResponseDto
+
+    @DELETE("/api/tasks/{taskId}")
+    suspend fun deleteTask(@Path("taskId") taskId: Long)
+
+    // Comments
+    @GET("/api/tasks/{taskId}/comments")
+    suspend fun getComments(@Path("taskId") taskId: Long): List<CommentDto>
+
+    @POST("/api/tasks/{taskId}/comments")
+    suspend fun addComment(@Path("taskId") taskId: Long, @Body request: CommentRequest): CommentDto
+
+    // Attachments
+    @GET("/api/tasks/{taskId}/attachments")
+    suspend fun getAttachments(@Path("taskId") taskId: Long): List<AttachmentDto>
+
+    @Multipart
+    @POST("/api/tasks/{taskId}/attachments")
+    suspend fun uploadAttachment(
+        @Path("taskId") taskId: Long,
+        @Part file: MultipartBody.Part
+    ): AttachmentDto
+
+    // Stats
+    @GET("/api/stats/tasks-by-status")
+    suspend fun statsByStatus(@Query("projectId") projectId: Long): List<StatsDto>
+
+    @GET("/api/stats/tasks-by-priority")
+    suspend fun statsByPriority(@Query("projectId") projectId: Long): List<StatsDto>
+}

--- a/android/app/src/main/java/com/example/minitasker/data/api/AuthInterceptor.kt
+++ b/android/app/src/main/java/com/example/minitasker/data/api/AuthInterceptor.kt
@@ -1,0 +1,22 @@
+package com.example.minitasker.data.api
+
+import com.example.minitasker.data.local.AuthPreferences
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import okhttp3.Interceptor
+import okhttp3.Response
+
+class AuthInterceptor(private val authPreferences: AuthPreferences) : Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val original = chain.request()
+        val token = runBlocking { authPreferences.tokenFlow.first() }
+        val request = if (!token.isNullOrEmpty()) {
+            original.newBuilder()
+                .addHeader("Authorization", "Bearer $token")
+                .build()
+        } else {
+            original
+        }
+        return chain.proceed(request)
+    }
+}

--- a/android/app/src/main/java/com/example/minitasker/data/local/AuthPreferences.kt
+++ b/android/app/src/main/java/com/example/minitasker/data/local/AuthPreferences.kt
@@ -1,0 +1,43 @@
+package com.example.minitasker.data.local
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "auth")
+
+class AuthPreferences(private val context: Context) {
+
+    companion object {
+        private val KEY_TOKEN = stringPreferencesKey("token")
+        private val KEY_EMAIL = stringPreferencesKey("email")
+        private val KEY_FULL_NAME = stringPreferencesKey("full_name")
+        private val KEY_ROLE = stringPreferencesKey("role")
+    }
+
+    val tokenFlow: Flow<String?> = context.dataStore.data.map { prefs ->
+        prefs[KEY_TOKEN]
+    }
+
+    val roleFlow: Flow<String?> = context.dataStore.data.map { prefs ->
+        prefs[KEY_ROLE]
+    }
+
+    suspend fun saveAuth(token: String, email: String, fullName: String, role: String) {
+        context.dataStore.edit { prefs ->
+            prefs[KEY_TOKEN] = token
+            prefs[KEY_EMAIL] = email
+            prefs[KEY_FULL_NAME] = fullName
+            prefs[KEY_ROLE] = role
+        }
+    }
+
+    suspend fun clear() {
+        context.dataStore.edit { it.clear() }
+    }
+}

--- a/android/app/src/main/java/com/example/minitasker/data/model/AuthModels.kt
+++ b/android/app/src/main/java/com/example/minitasker/data/model/AuthModels.kt
@@ -1,0 +1,28 @@
+package com.example.minitasker.data.model
+
+data class RegisterRequest(
+    val email: String,
+    val password: String,
+    val fullName: String
+)
+
+data class LoginRequest(
+    val email: String,
+    val password: String
+)
+
+data class AuthResponse(
+    val token: String,
+    val userId: Long,
+    val email: String,
+    val fullName: String,
+    val role: String
+)
+
+data class UserDto(
+    val id: Long,
+    val email: String,
+    val fullName: String,
+    val role: String,
+    val createdAt: String
+)

--- a/android/app/src/main/java/com/example/minitasker/data/model/ProjectModels.kt
+++ b/android/app/src/main/java/com/example/minitasker/data/model/ProjectModels.kt
@@ -1,0 +1,23 @@
+package com.example.minitasker.data.model
+
+data class ProjectRequest(
+    val name: String,
+    val description: String?
+)
+
+data class ProjectDto(
+    val id: Long,
+    val name: String,
+    val description: String?,
+    val ownerId: Long,
+    val ownerName: String,
+    val createdAt: String
+)
+
+data class PagedResponse<T>(
+    val content: List<T>,
+    val totalElements: Long,
+    val totalPages: Int,
+    val page: Int,
+    val size: Int
+)

--- a/android/app/src/main/java/com/example/minitasker/data/model/TaskModels.kt
+++ b/android/app/src/main/java/com/example/minitasker/data/model/TaskModels.kt
@@ -1,0 +1,63 @@
+package com.example.minitasker.data.model
+
+import com.squareup.moshi.Json
+
+data class TaskRequest(
+    val title: String,
+    val description: String?,
+    val status: String,
+    val priority: String,
+    val assigneeId: Long?,
+    val dueDate: String?
+)
+
+data class TaskSummaryDto(
+    val id: Long,
+    val title: String,
+    val status: String,
+    val priority: String,
+    val dueDate: String?,
+    val assigneeName: String?
+)
+
+data class TaskResponseDto(
+    val id: Long,
+    val projectId: Long,
+    val title: String,
+    val description: String?,
+    val status: String,
+    val priority: String,
+    val assigneeId: Long?,
+    val assigneeName: String?,
+    val dueDate: String?,
+    val createdAt: String,
+    val comments: List<CommentDto>,
+    val attachments: List<AttachmentDto>
+)
+
+data class CommentDto(
+    val id: Long,
+    val taskId: Long,
+    val authorId: Long,
+    val authorName: String,
+    val text: String,
+    val createdAt: String
+)
+
+data class CommentRequest(
+    val text: String
+)
+
+data class AttachmentDto(
+    val id: Long,
+    val taskId: Long?,
+    val fileName: String,
+    val contentType: String,
+    val url: String,
+    val uploadedAt: String
+)
+
+data class StatsDto(
+    val key: String,
+    val value: Long
+)

--- a/android/app/src/main/java/com/example/minitasker/data/repository/AuthRepository.kt
+++ b/android/app/src/main/java/com/example/minitasker/data/repository/AuthRepository.kt
@@ -1,0 +1,36 @@
+package com.example.minitasker.data.repository
+
+import com.example.minitasker.data.api.ApiService
+import com.example.minitasker.data.local.AuthPreferences
+import com.example.minitasker.data.model.AuthResponse
+import com.example.minitasker.data.model.LoginRequest
+import com.example.minitasker.data.model.RegisterRequest
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+
+class AuthRepository(
+    private val apiService: ApiService,
+    private val authPreferences: AuthPreferences
+) {
+
+    val tokenFlow: Flow<String?> = authPreferences.tokenFlow
+    val roleFlow: Flow<String?> = authPreferences.roleFlow
+
+    suspend fun register(email: String, password: String, fullName: String): AuthResponse {
+        val response = apiService.register(RegisterRequest(email, password, fullName))
+        authPreferences.saveAuth(response.token, response.email, response.fullName, response.role)
+        return response
+    }
+
+    suspend fun login(email: String, password: String): AuthResponse {
+        val response = apiService.login(LoginRequest(email, password))
+        authPreferences.saveAuth(response.token, response.email, response.fullName, response.role)
+        return response
+    }
+
+    suspend fun logout() {
+        authPreferences.clear()
+    }
+
+    suspend fun currentToken(): String? = tokenFlow.first()
+}

--- a/android/app/src/main/java/com/example/minitasker/data/repository/NetworkResult.kt
+++ b/android/app/src/main/java/com/example/minitasker/data/repository/NetworkResult.kt
@@ -1,0 +1,7 @@
+package com.example.minitasker.data.repository
+
+sealed class NetworkResult<out T> {
+    object Loading : NetworkResult<Nothing>()
+    data class Success<T>(val data: T) : NetworkResult<T>()
+    data class Error(val message: String) : NetworkResult<Nothing>()
+}

--- a/android/app/src/main/java/com/example/minitasker/data/repository/ProjectRepository.kt
+++ b/android/app/src/main/java/com/example/minitasker/data/repository/ProjectRepository.kt
@@ -1,0 +1,25 @@
+package com.example.minitasker.data.repository
+
+import com.example.minitasker.data.api.ApiService
+import com.example.minitasker.data.model.PagedResponse
+import com.example.minitasker.data.model.ProjectDto
+import com.example.minitasker.data.model.ProjectRequest
+
+class ProjectRepository(private val apiService: ApiService) {
+
+    suspend fun loadProjects(filter: String?, page: Int, size: Int): PagedResponse<ProjectDto> {
+        return apiService.getProjects(filter, page, size)
+    }
+
+    suspend fun createProject(name: String, description: String?): ProjectDto {
+        return apiService.createProject(ProjectRequest(name, description))
+    }
+
+    suspend fun updateProject(id: Long, name: String, description: String?): ProjectDto {
+        return apiService.updateProject(id, ProjectRequest(name, description))
+    }
+
+    suspend fun deleteProject(id: Long) {
+        apiService.deleteProject(id)
+    }
+}

--- a/android/app/src/main/java/com/example/minitasker/data/repository/SafeCall.kt
+++ b/android/app/src/main/java/com/example/minitasker/data/repository/SafeCall.kt
@@ -1,0 +1,17 @@
+package com.example.minitasker.data.repository
+
+import retrofit2.HttpException
+import java.io.IOException
+
+suspend fun <T> safeCall(block: suspend () -> T): NetworkResult<T> {
+    return try {
+        NetworkResult.Success(block())
+    } catch (ex: HttpException) {
+        val message = ex.response()?.errorBody()?.string() ?: ex.message()
+        NetworkResult.Error(message ?: "Server error")
+    } catch (ex: IOException) {
+        NetworkResult.Error("Network error: ${ex.message}")
+    } catch (ex: Exception) {
+        NetworkResult.Error(ex.message ?: "Unknown error")
+    }
+}

--- a/android/app/src/main/java/com/example/minitasker/data/repository/ServiceLocator.kt
+++ b/android/app/src/main/java/com/example/minitasker/data/repository/ServiceLocator.kt
@@ -1,0 +1,57 @@
+package com.example.minitasker.data.repository
+
+import android.content.Context
+import com.example.minitasker.data.api.ApiService
+import com.example.minitasker.data.api.AuthInterceptor
+import com.example.minitasker.data.local.AuthPreferences
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import retrofit2.Retrofit
+import retrofit2.converter.moshi.MoshiConverterFactory
+
+object ServiceLocator {
+
+    private const val BASE_URL = "http://10.0.2.2:8080"
+
+    fun provideAuthPreferences(context: Context): AuthPreferences = AuthPreferences(context)
+
+    fun provideApiService(context: Context): ApiService {
+        val authPreferences = provideAuthPreferences(context)
+        val logging = HttpLoggingInterceptor().apply {
+            level = HttpLoggingInterceptor.Level.BODY
+        }
+        val client = OkHttpClient.Builder()
+            .addInterceptor(AuthInterceptor(authPreferences))
+            .addInterceptor(logging)
+            .build()
+        val moshi = Moshi.Builder()
+            .addLast(KotlinJsonAdapterFactory())
+            .build()
+        val retrofit = Retrofit.Builder()
+            .baseUrl(BASE_URL)
+            .client(client)
+            .addConverterFactory(MoshiConverterFactory.create(moshi))
+            .build()
+        return retrofit.create(ApiService::class.java)
+    }
+
+    fun provideAuthRepository(context: Context): AuthRepository {
+        val preferences = provideAuthPreferences(context)
+        val api = provideApiService(context)
+        return AuthRepository(api, preferences)
+    }
+
+    fun provideProjectRepository(context: Context): ProjectRepository {
+        return ProjectRepository(provideApiService(context))
+    }
+
+    fun provideTaskRepository(context: Context): TaskRepository {
+        return TaskRepository(context, provideApiService(context))
+    }
+
+    fun provideStatsRepository(context: Context): StatsRepository {
+        return StatsRepository(provideApiService(context))
+    }
+}

--- a/android/app/src/main/java/com/example/minitasker/data/repository/StatsRepository.kt
+++ b/android/app/src/main/java/com/example/minitasker/data/repository/StatsRepository.kt
@@ -1,0 +1,9 @@
+package com.example.minitasker.data.repository
+
+import com.example.minitasker.data.api.ApiService
+import com.example.minitasker.data.model.StatsDto
+
+class StatsRepository(private val apiService: ApiService) {
+    suspend fun loadStatusStats(projectId: Long): List<StatsDto> = apiService.statsByStatus(projectId)
+    suspend fun loadPriorityStats(projectId: Long): List<StatsDto> = apiService.statsByPriority(projectId)
+}

--- a/android/app/src/main/java/com/example/minitasker/data/repository/TaskRepository.kt
+++ b/android/app/src/main/java/com/example/minitasker/data/repository/TaskRepository.kt
@@ -1,0 +1,81 @@
+package com.example.minitasker.data.repository
+
+import android.content.ContentResolver
+import android.content.Context
+import android.net.Uri
+import android.provider.OpenableColumns
+import com.example.minitasker.data.api.ApiService
+import com.example.minitasker.data.model.AttachmentDto
+import com.example.minitasker.data.model.CommentDto
+import com.example.minitasker.data.model.CommentRequest
+import com.example.minitasker.data.model.PagedResponse
+import com.example.minitasker.data.model.TaskRequest
+import com.example.minitasker.data.model.TaskResponseDto
+import com.example.minitasker.data.model.TaskSummaryDto
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.MultipartBody
+import okhttp3.RequestBody
+import okhttp3.RequestBody.Companion.toRequestBody
+
+class TaskRepository(private val context: Context, private val apiService: ApiService) {
+
+    suspend fun loadTasks(
+        projectId: Long,
+        status: String?,
+        priority: String?,
+        assigneeId: Long?,
+        page: Int,
+        size: Int
+    ): PagedResponse<TaskSummaryDto> {
+        return apiService.getTasks(projectId, status, priority, assigneeId, page, size)
+    }
+
+    suspend fun createTask(projectId: Long, request: TaskRequest): TaskResponseDto {
+        return apiService.createTask(projectId, request)
+    }
+
+    suspend fun getTask(taskId: Long): TaskResponseDto {
+        return apiService.getTask(taskId)
+    }
+
+    suspend fun updateTask(taskId: Long, request: TaskRequest): TaskResponseDto {
+        return apiService.updateTask(taskId, request)
+    }
+
+    suspend fun deleteTask(taskId: Long) {
+        apiService.deleteTask(taskId)
+    }
+
+    suspend fun getComments(taskId: Long): List<CommentDto> {
+        return apiService.getComments(taskId)
+    }
+
+    suspend fun addComment(taskId: Long, text: String): CommentDto {
+        return apiService.addComment(taskId, CommentRequest(text))
+    }
+
+    suspend fun getAttachments(taskId: Long): List<AttachmentDto> {
+        return apiService.getAttachments(taskId)
+    }
+
+    suspend fun uploadAttachment(taskId: Long, uri: Uri): AttachmentDto {
+        val resolver = context.contentResolver
+        val fileName = resolveFileName(resolver, uri) ?: "attachment"
+        val mime = resolver.getType(uri) ?: "application/octet-stream"
+        val bytes = resolver.openInputStream(uri)?.use { it.readBytes() }
+            ?: throw IllegalArgumentException("Не удалось прочитать файл")
+        val requestBody: RequestBody = bytes.toRequestBody(mime.toMediaTypeOrNull())
+        val part = MultipartBody.Part.createFormData("file", fileName, requestBody)
+        return apiService.uploadAttachment(taskId, part)
+    }
+
+    private fun resolveFileName(resolver: ContentResolver, uri: Uri): String? {
+        resolver.query(uri, null, null, null, null)?.use { cursor ->
+            val nameIndex = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+            if (cursor.moveToFirst() && nameIndex >= 0) {
+                return cursor.getString(nameIndex)
+            }
+        }
+        return null
+    }
+}

--- a/android/app/src/main/java/com/example/minitasker/ui/components/Components.kt
+++ b/android/app/src/main/java/com/example/minitasker/ui/components/Components.kt
@@ -1,0 +1,41 @@
+package com.example.minitasker.ui.components
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun PrimaryButton(text: String, onClick: () -> Unit, enabled: Boolean = true) {
+    Button(onClick = onClick, modifier = Modifier
+        .fillMaxWidth()
+        .padding(vertical = 8.dp), enabled = enabled) {
+        Text(text = text)
+    }
+}
+
+@Composable
+fun LabeledTextField(value: String, onValueChange: (String) -> Unit, label: String, isPassword: Boolean = false) {
+    OutlinedTextField(
+        value = value,
+        onValueChange = onValueChange,
+        label = { Text(label) },
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp),
+        visualTransformation = if (isPassword) PasswordVisualTransformation() else androidx.compose.ui.text.input.VisualTransformation.None
+    )
+}
+
+@Composable
+fun ErrorText(message: String?) {
+    if (message != null) {
+        Text(text = message, color = MaterialTheme.colorScheme.error, modifier = Modifier.padding(vertical = 4.dp))
+    }
+}

--- a/android/app/src/main/java/com/example/minitasker/ui/navigation/NavRoutes.kt
+++ b/android/app/src/main/java/com/example/minitasker/ui/navigation/NavRoutes.kt
@@ -1,0 +1,15 @@
+package com.example.minitasker.ui.navigation
+
+sealed class Screen(val route: String) {
+    object Auth : Screen("auth")
+    object Projects : Screen("projects")
+    object Tasks : Screen("tasks/{projectId}/{projectName}") {
+        fun create(projectId: Long, projectName: String) = "tasks/$projectId/${projectName}"
+    }
+    object TaskDetail : Screen("taskDetail/{taskId}") {
+        fun create(taskId: Long) = "taskDetail/$taskId"
+    }
+    object Stats : Screen("stats/{projectId}/{projectName}") {
+        fun create(projectId: Long, projectName: String) = "stats/$projectId/${projectName}"
+    }
+}

--- a/android/app/src/main/java/com/example/minitasker/ui/screen/auth/AuthScreen.kt
+++ b/android/app/src/main/java/com/example/minitasker/ui/screen/auth/AuthScreen.kt
@@ -1,0 +1,60 @@
+package com.example.minitasker.ui.screen.auth
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.example.minitasker.ui.components.ErrorText
+import com.example.minitasker.ui.components.LabeledTextField
+import com.example.minitasker.ui.components.PrimaryButton
+
+@Composable
+fun AuthScreen(viewModel: AuthViewModel, onAuthenticated: () -> Unit) {
+    val state by viewModel.state.collectAsState()
+
+    if (state.isAuthenticated) {
+        onAuthenticated()
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(24.dp)
+            .verticalScroll(rememberScrollState()),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = if (state.isRegister) "Регистрация" else "Вход",
+            style = MaterialTheme.typography.headlineMedium
+        )
+        Spacer(modifier = Modifier.height(24.dp))
+        LabeledTextField(value = state.email, onValueChange = viewModel::updateEmail, label = "Email")
+        LabeledTextField(value = state.password, onValueChange = viewModel::updatePassword, label = "Пароль", isPassword = true)
+        if (state.isRegister) {
+            LabeledTextField(value = state.fullName, onValueChange = viewModel::updateFullName, label = "Имя")
+        }
+        ErrorText(message = state.error)
+        if (state.loading) {
+            CircularProgressIndicator()
+        } else {
+            PrimaryButton(text = if (state.isRegister) "Создать аккаунт" else "Войти", onClick = viewModel::submit)
+        }
+        Spacer(modifier = Modifier.height(8.dp))
+        PrimaryButton(
+            text = if (state.isRegister) "У меня уже есть аккаунт" else "Регистрация",
+            onClick = viewModel::toggleMode
+        )
+    }
+}

--- a/android/app/src/main/java/com/example/minitasker/ui/screen/auth/AuthViewModel.kt
+++ b/android/app/src/main/java/com/example/minitasker/ui/screen/auth/AuthViewModel.kt
@@ -1,0 +1,69 @@
+package com.example.minitasker.ui.screen.auth
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.minitasker.data.repository.AuthRepository
+import com.example.minitasker.data.repository.NetworkResult
+import com.example.minitasker.data.repository.safeCall
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+data class AuthUiState(
+    val email: String = "",
+    val password: String = "",
+    val fullName: String = "",
+    val isRegister: Boolean = false,
+    val loading: Boolean = false,
+    val error: String? = null,
+    val isAuthenticated: Boolean = false
+)
+
+class AuthViewModel(private val authRepository: AuthRepository) : ViewModel() {
+
+    private val _state = MutableStateFlow(AuthUiState())
+    val state: StateFlow<AuthUiState> = _state.asStateFlow()
+
+    fun updateEmail(value: String) {
+        _state.value = _state.value.copy(email = value)
+    }
+
+    fun updatePassword(value: String) {
+        _state.value = _state.value.copy(password = value)
+    }
+
+    fun updateFullName(value: String) {
+        _state.value = _state.value.copy(fullName = value)
+    }
+
+    fun toggleMode() {
+        _state.value = _state.value.copy(isRegister = !_state.value.isRegister, error = null)
+    }
+
+    fun reset() {
+        _state.value = AuthUiState()
+    }
+
+    fun submit() {
+        viewModelScope.launch {
+            _state.value = _state.value.copy(loading = true, error = null)
+            val result = if (_state.value.isRegister) {
+                safeCall {
+                    authRepository.register(
+                        _state.value.email,
+                        _state.value.password,
+                        _state.value.fullName
+                    )
+                }
+            } else {
+                safeCall { authRepository.login(_state.value.email, _state.value.password) }
+            }
+            _state.value = when (result) {
+                is NetworkResult.Success -> _state.value.copy(loading = false, isAuthenticated = true)
+                is NetworkResult.Error -> _state.value.copy(loading = false, error = result.message)
+                NetworkResult.Loading -> _state.value.copy(loading = true)
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/example/minitasker/ui/screen/projects/ProjectsScreen.kt
+++ b/android/app/src/main/java/com/example/minitasker/ui/screen/projects/ProjectsScreen.kt
@@ -1,0 +1,130 @@
+package com.example.minitasker.ui.screen.projects
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.icons.Icons
+import androidx.compose.material3.icons.filled.Add
+import androidx.compose.material3.icons.filled.Logout
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.example.minitasker.data.model.ProjectDto
+import com.example.minitasker.ui.components.LabeledTextField
+
+@Composable
+fun ProjectsScreen(
+    viewModel: ProjectsViewModel,
+    onProjectSelected: (ProjectDto) -> Unit,
+    onShowStats: (ProjectDto) -> Unit,
+    onLoggedOut: () -> Unit
+) {
+    val state by viewModel.state.collectAsState()
+    var projectName by remember { mutableStateOf("") }
+    var projectDescription by remember { mutableStateOf("") }
+
+    LaunchedEffect(Unit) {
+        viewModel.refresh()
+    }
+
+    if (state.showCreateDialog) {
+        AlertDialog(
+            onDismissRequest = { viewModel.toggleCreateDialog(false) },
+            confirmButton = {
+                TextButton(onClick = {
+                    viewModel.createProject(projectName, projectDescription)
+                    projectName = ""
+                    projectDescription = ""
+                }) { Text("Создать") }
+            },
+            dismissButton = {
+                TextButton(onClick = { viewModel.toggleCreateDialog(false) }) { Text("Отмена") }
+            },
+            title = { Text("Новый проект") },
+            text = {
+                Column {
+                    LabeledTextField(value = projectName, onValueChange = { projectName = it }, label = "Название")
+                    LabeledTextField(value = projectDescription, onValueChange = { projectDescription = it }, label = "Описание")
+                }
+            }
+        )
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Проекты MiniTasker") },
+                actions = {
+                    IconButton(onClick = { viewModel.logout(onLoggedOut) }) {
+                        Icon(imageVector = Icons.Default.Logout, contentDescription = null)
+                    }
+                }
+            )
+        },
+        floatingActionButton = {
+            FloatingActionButton(onClick = { viewModel.toggleCreateDialog(true) }) {
+                Icon(imageVector = Icons.Default.Add, contentDescription = null)
+            }
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .padding(padding)
+                .fillMaxSize()
+                .padding(16.dp)
+        ) {
+            if (state.loading) {
+                CircularProgressIndicator()
+            }
+            LazyColumn(verticalArrangement = Arrangement.spacedBy(12.dp), modifier = Modifier.weight(1f, fill = false)) {
+                items(state.projects) { project ->
+                    ProjectCard(project = project, onProjectSelected = onProjectSelected, onShowStats = onShowStats)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ProjectCard(project: ProjectDto, onProjectSelected: (ProjectDto) -> Unit, onShowStats: (ProjectDto) -> Unit) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onProjectSelected(project) }
+            .padding(16.dp)
+    ) {
+        Text(text = project.name, style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.Bold)
+        Spacer(modifier = Modifier.height(4.dp))
+        Text(text = project.description ?: "Без описания", style = MaterialTheme.typography.bodyMedium)
+        Spacer(modifier = Modifier.height(8.dp))
+        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+            Text(text = "Владелец: ${project.ownerName}")
+            TextButton(onClick = { onShowStats(project) }) { Text("Статистика") }
+        }
+    }
+}

--- a/android/app/src/main/java/com/example/minitasker/ui/screen/projects/ProjectsViewModel.kt
+++ b/android/app/src/main/java/com/example/minitasker/ui/screen/projects/ProjectsViewModel.kt
@@ -1,0 +1,72 @@
+package com.example.minitasker.ui.screen.projects
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.minitasker.data.model.ProjectDto
+import com.example.minitasker.data.repository.AuthRepository
+import com.example.minitasker.data.repository.NetworkResult
+import com.example.minitasker.data.repository.ProjectRepository
+import com.example.minitasker.data.repository.safeCall
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+data class ProjectsUiState(
+    val projects: List<ProjectDto> = emptyList(),
+    val loading: Boolean = false,
+    val error: String? = null,
+    val showCreateDialog: Boolean = false
+)
+
+class ProjectsViewModel(
+    private val projectRepository: ProjectRepository,
+    private val authRepository: AuthRepository
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(ProjectsUiState())
+    val state: StateFlow<ProjectsUiState> = _state.asStateFlow()
+
+    init {
+        refresh()
+    }
+
+    fun refresh() {
+        viewModelScope.launch {
+            _state.value = _state.value.copy(loading = true, error = null)
+            when (val result = safeCall { projectRepository.loadProjects(null, 0, 100) }) {
+                is NetworkResult.Success -> _state.value = _state.value.copy(
+                    loading = false,
+                    projects = result.data.content
+                )
+                is NetworkResult.Error -> _state.value = _state.value.copy(loading = false, error = result.message)
+                NetworkResult.Loading -> _state.value = _state.value.copy(loading = true)
+            }
+        }
+    }
+
+    fun toggleCreateDialog(show: Boolean) {
+        _state.value = _state.value.copy(showCreateDialog = show)
+    }
+
+    fun createProject(name: String, description: String) {
+        viewModelScope.launch {
+            _state.value = _state.value.copy(loading = true)
+            when (val result = safeCall { projectRepository.createProject(name, description.ifBlank { null }) }) {
+                is NetworkResult.Success -> {
+                    val newList = _state.value.projects + result.data
+                    _state.value = _state.value.copy(projects = newList, loading = false, showCreateDialog = false)
+                }
+                is NetworkResult.Error -> _state.value = _state.value.copy(loading = false, error = result.message)
+                NetworkResult.Loading -> _state.value = _state.value.copy(loading = true)
+            }
+        }
+    }
+
+    fun logout(onComplete: () -> Unit) {
+        viewModelScope.launch {
+            authRepository.logout()
+            onComplete()
+        }
+    }
+}

--- a/android/app/src/main/java/com/example/minitasker/ui/screen/stats/StatsScreen.kt
+++ b/android/app/src/main/java/com/example/minitasker/ui/screen/stats/StatsScreen.kt
@@ -1,0 +1,48 @@
+package com.example.minitasker.ui.screen.stats
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.viewinterop.AndroidView
+import com.github.mikephil.charting.charts.PieChart
+import com.github.mikephil.charting.data.PieData
+import com.github.mikephil.charting.data.PieDataSet
+import com.github.mikephil.charting.data.PieEntry
+
+@Composable
+fun StatsScreen(projectId: Long, projectName: String, viewModel: StatsViewModel) {
+    val state by viewModel.state.collectAsState()
+
+    LaunchedEffect(projectId) {
+        viewModel.load(projectId)
+    }
+
+    Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
+        Text(text = "Статистика по проекту $projectName", style = MaterialTheme.typography.headlineSmall)
+        AndroidView(factory = { context ->
+            PieChart(context).apply {
+                description.isEnabled = false
+            }
+        }, update = { chart ->
+            val entries = state.statusStats.map { PieEntry(it.value.toFloat(), it.key) }
+            val dataSet = PieDataSet(entries, "Статусы")
+            chart.data = PieData(dataSet)
+            chart.invalidate()
+        })
+        AndroidView(factory = { context ->
+            PieChart(context).apply { description.isEnabled = false }
+        }, update = { chart ->
+            val entries = state.priorityStats.map { PieEntry(it.value.toFloat(), it.key) }
+            val dataSet = PieDataSet(entries, "Приоритеты")
+            chart.data = PieData(dataSet)
+            chart.invalidate()
+        })
+    }
+}

--- a/android/app/src/main/java/com/example/minitasker/ui/screen/stats/StatsViewModel.kt
+++ b/android/app/src/main/java/com/example/minitasker/ui/screen/stats/StatsViewModel.kt
@@ -1,0 +1,41 @@
+package com.example.minitasker.ui.screen.stats
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.minitasker.data.model.StatsDto
+import com.example.minitasker.data.repository.NetworkResult
+import com.example.minitasker.data.repository.StatsRepository
+import com.example.minitasker.data.repository.safeCall
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+data class StatsUiState(
+    val statusStats: List<StatsDto> = emptyList(),
+    val priorityStats: List<StatsDto> = emptyList(),
+    val loading: Boolean = false,
+    val error: String? = null
+)
+
+class StatsViewModel(private val repository: StatsRepository) : ViewModel() {
+
+    private val _state = MutableStateFlow(StatsUiState())
+    val state: StateFlow<StatsUiState> = _state.asStateFlow()
+
+    fun load(projectId: Long) {
+        viewModelScope.launch {
+            _state.value = _state.value.copy(loading = true, error = null)
+            when (val statusResult = safeCall { repository.loadStatusStats(projectId) }) {
+                is NetworkResult.Success -> _state.value = _state.value.copy(statusStats = statusResult.data)
+                is NetworkResult.Error -> _state.value = _state.value.copy(error = statusResult.message)
+                NetworkResult.Loading -> Unit
+            }
+            when (val priorityResult = safeCall { repository.loadPriorityStats(projectId) }) {
+                is NetworkResult.Success -> _state.value = _state.value.copy(priorityStats = priorityResult.data, loading = false)
+                is NetworkResult.Error -> _state.value = _state.value.copy(error = priorityResult.message, loading = false)
+                NetworkResult.Loading -> Unit
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/example/minitasker/ui/screen/taskdetail/TaskDetailScreen.kt
+++ b/android/app/src/main/java/com/example/minitasker/ui/screen/taskdetail/TaskDetailScreen.kt
@@ -1,0 +1,158 @@
+package com.example.minitasker.ui.screen.taskdetail
+
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.AssistChipDefaults
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.example.minitasker.data.model.TaskRequest
+
+@Composable
+fun TaskDetailScreen(taskId: Long, viewModel: TaskDetailViewModel) {
+    val state by viewModel.state.collectAsState()
+    var commentText by remember { mutableStateOf("") }
+    val filePicker = rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri ->
+        if (uri != null) {
+            viewModel.uploadAttachment(taskId, uri)
+        }
+    }
+
+    LaunchedEffect(taskId) {
+        viewModel.loadTask(taskId)
+    }
+
+    Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
+        state.task?.let { task ->
+            Text(text = task.title, style = MaterialTheme.typography.headlineSmall, fontWeight = FontWeight.Bold)
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(text = task.description ?: "Нет описания")
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(text = "Статус: ${task.status}")
+            Text(text = "Приоритет: ${task.priority}")
+            task.assigneeName?.let { Text(text = "Исполнитель: $it") }
+            task.dueDate?.let { Text(text = "Срок: $it") }
+            Spacer(modifier = Modifier.height(12.dp))
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                StatusChip(label = "TODO", selected = task.status == "TODO") {
+                    viewModel.updateTask(taskId, task.toRequest(status = "TODO"))
+                }
+                StatusChip(label = "IN_PROGRESS", selected = task.status == "IN_PROGRESS") {
+                    viewModel.updateTask(taskId, task.toRequest(status = "IN_PROGRESS"))
+                }
+                StatusChip(label = "DONE", selected = task.status == "DONE") {
+                    viewModel.updateTask(taskId, task.toRequest(status = "DONE"))
+                }
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                StatusChip(label = "LOW", selected = task.priority == "LOW") {
+                    viewModel.updateTask(taskId, task.toRequest(priority = "LOW"))
+                }
+                StatusChip(label = "MEDIUM", selected = task.priority == "MEDIUM") {
+                    viewModel.updateTask(taskId, task.toRequest(priority = "MEDIUM"))
+                }
+                StatusChip(label = "HIGH", selected = task.priority == "HIGH") {
+                    viewModel.updateTask(taskId, task.toRequest(priority = "HIGH"))
+                }
+            }
+            Spacer(modifier = Modifier.height(16.dp))
+            Text(text = "Комментарии", style = MaterialTheme.typography.titleMedium)
+            LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp), modifier = Modifier.weight(1f, fill = false)) {
+                items(task.comments) { comment ->
+                    Card(elevation = CardDefaults.cardElevation(defaultElevation = 1.dp)) {
+                        Column(modifier = Modifier.padding(12.dp)) {
+                            Text(text = comment.authorName, fontWeight = FontWeight.SemiBold)
+                            Text(text = comment.text)
+                            Text(text = comment.createdAt, style = MaterialTheme.typography.labelSmall)
+                        }
+                    }
+                }
+            }
+            Spacer(modifier = Modifier.height(12.dp))
+            Text(text = "Вложения", style = MaterialTheme.typography.titleMedium)
+            LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp), modifier = Modifier.weight(1f, fill = false)) {
+                items(task.attachments) { attachment ->
+                    Card(elevation = CardDefaults.cardElevation(defaultElevation = 1.dp)) {
+                        Column(modifier = Modifier.padding(12.dp)) {
+                            Text(text = attachment.fileName, fontWeight = FontWeight.SemiBold)
+                            Text(text = attachment.uploadedAt, style = MaterialTheme.typography.labelSmall)
+                            Text(text = attachment.url, style = MaterialTheme.typography.bodySmall)
+                        }
+                    }
+                }
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+            OutlinedTextField(
+                value = commentText,
+                onValueChange = { commentText = it },
+                modifier = Modifier.fillMaxWidth(),
+                label = { Text("Добавить комментарий") }
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Button(onClick = {
+                if (commentText.isNotBlank()) {
+                    viewModel.addComment(taskId, commentText)
+                    commentText = ""
+                }
+            }) {
+                Text("Отправить")
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+            Button(onClick = { filePicker.launch("*") }) {
+                Text("Прикрепить файл")
+            }
+        } ?: Text("Загрузка...")
+    }
+}
+
+private fun com.example.minitasker.data.model.TaskResponseDto.toRequest(
+    status: String = this.status,
+    priority: String = this.priority
+): TaskRequest {
+    return TaskRequest(
+        title = this.title,
+        description = this.description,
+        status = status,
+        priority = priority,
+        assigneeId = this.assigneeId,
+        dueDate = this.dueDate
+    )
+}
+
+@Composable
+private fun StatusChip(label: String, selected: Boolean, onClick: () -> Unit) {
+    AssistChip(
+        onClick = onClick,
+        label = { Text(label) },
+        colors = if (selected) {
+            AssistChipDefaults.assistChipColors(containerColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.2f))
+        } else {
+            AssistChipDefaults.assistChipColors()
+        }
+    )
+}

--- a/android/app/src/main/java/com/example/minitasker/ui/screen/taskdetail/TaskDetailViewModel.kt
+++ b/android/app/src/main/java/com/example/minitasker/ui/screen/taskdetail/TaskDetailViewModel.kt
@@ -1,0 +1,84 @@
+package com.example.minitasker.ui.screen.taskdetail
+
+import android.net.Uri
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.minitasker.data.model.TaskRequest
+import com.example.minitasker.data.model.TaskResponseDto
+import com.example.minitasker.data.repository.NetworkResult
+import com.example.minitasker.data.repository.TaskRepository
+import com.example.minitasker.data.repository.safeCall
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+
+data class TaskDetailUiState(
+    val task: TaskResponseDto? = null,
+    val loading: Boolean = false,
+    val error: String? = null
+)
+
+class TaskDetailViewModel(private val repository: TaskRepository) : ViewModel() {
+
+    private val _state = MutableStateFlow(TaskDetailUiState())
+    val state: StateFlow<TaskDetailUiState> = _state.asStateFlow()
+
+    fun loadTask(taskId: Long) {
+        viewModelScope.launch {
+            _state.value = _state.value.copy(loading = true, error = null)
+            when (val result = safeCall { repository.getTask(taskId) }) {
+                is NetworkResult.Success -> _state.value = _state.value.copy(task = result.data, loading = false)
+                is NetworkResult.Error -> _state.value = _state.value.copy(loading = false, error = result.message)
+                NetworkResult.Loading -> _state.value = _state.value.copy(loading = true)
+            }
+        }
+    }
+
+    fun updateTask(taskId: Long, request: TaskRequest) {
+        viewModelScope.launch {
+            when (val result = safeCall { repository.updateTask(taskId, request) }) {
+                is NetworkResult.Success -> _state.value = _state.value.copy(task = result.data, error = null)
+                is NetworkResult.Error -> _state.value = _state.value.copy(error = result.message)
+                NetworkResult.Loading -> Unit
+            }
+        }
+    }
+
+    fun addComment(taskId: Long, text: String) {
+        viewModelScope.launch {
+            when (val result = safeCall { repository.addComment(taskId, text) }) {
+                is NetworkResult.Success -> {
+                    val task = _state.value.task
+                    if (task != null) {
+                        val updated = task.copy(comments = task.comments + result.data)
+                        _state.value = _state.value.copy(task = updated)
+                    } else {
+                        loadTask(taskId)
+                    }
+                }
+                is NetworkResult.Error -> _state.value = _state.value.copy(error = result.message)
+                NetworkResult.Loading -> Unit
+            }
+        }
+    }
+
+    fun uploadAttachment(taskId: Long, uri: Uri) {
+        viewModelScope.launch {
+            when (val result = safeCall { repository.uploadAttachment(taskId, uri) }) {
+                is NetworkResult.Success -> {
+                    val task = _state.value.task
+                    if (task != null) {
+                        val updated = task.copy(attachments = task.attachments + result.data)
+                        _state.value = _state.value.copy(task = updated)
+                    } else {
+                        loadTask(taskId)
+                    }
+                }
+                is NetworkResult.Error -> _state.value = _state.value.copy(error = result.message)
+                NetworkResult.Loading -> Unit
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/example/minitasker/ui/screen/tasks/TasksScreen.kt
+++ b/android/app/src/main/java/com/example/minitasker/ui/screen/tasks/TasksScreen.kt
@@ -1,0 +1,132 @@
+package com.example.minitasker.ui.screen.tasks
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.example.minitasker.data.model.TaskSummaryDto
+
+@Composable
+fun TasksScreen(
+    projectId: Long,
+    projectName: String,
+    viewModel: TasksViewModel,
+    onTaskSelected: (Long) -> Unit
+) {
+    val state by viewModel.state.collectAsState()
+    var newTaskTitle by remember { mutableStateOf("") }
+
+    LaunchedEffect(projectId) {
+        viewModel.loadTasks(projectId)
+    }
+
+    Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
+        Text(text = "Задачи проекта $projectName", style = MaterialTheme.typography.headlineSmall)
+        Spacer(modifier = Modifier.height(12.dp))
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            FilterChip(label = "Все", selected = state.status == TaskStatusFilter.ALL) {
+                viewModel.updateStatus(TaskStatusFilter.ALL, projectId)
+            }
+            FilterChip(label = "В работе", selected = state.status == TaskStatusFilter.IN_PROGRESS) {
+                viewModel.updateStatus(TaskStatusFilter.IN_PROGRESS, projectId)
+            }
+            FilterChip(label = "Сделать", selected = state.status == TaskStatusFilter.TODO) {
+                viewModel.updateStatus(TaskStatusFilter.TODO, projectId)
+            }
+            FilterChip(label = "Готово", selected = state.status == TaskStatusFilter.DONE) {
+                viewModel.updateStatus(TaskStatusFilter.DONE, projectId)
+            }
+        }
+        Spacer(modifier = Modifier.height(8.dp))
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            FilterChip(label = "Все приоритеты", selected = state.priority == TaskPriorityFilter.ALL) {
+                viewModel.updatePriority(TaskPriorityFilter.ALL, projectId)
+            }
+            FilterChip(label = "Высокий", selected = state.priority == TaskPriorityFilter.HIGH) {
+                viewModel.updatePriority(TaskPriorityFilter.HIGH, projectId)
+            }
+            FilterChip(label = "Средний", selected = state.priority == TaskPriorityFilter.MEDIUM) {
+                viewModel.updatePriority(TaskPriorityFilter.MEDIUM, projectId)
+            }
+            FilterChip(label = "Низкий", selected = state.priority == TaskPriorityFilter.LOW) {
+                viewModel.updatePriority(TaskPriorityFilter.LOW, projectId)
+            }
+        }
+        Spacer(modifier = Modifier.height(12.dp))
+        Row {
+            androidx.compose.material3.OutlinedTextField(
+                value = newTaskTitle,
+                onValueChange = { newTaskTitle = it },
+                label = { Text("Новая задача") },
+                modifier = Modifier.weight(1f)
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Button(onClick = {
+                if (newTaskTitle.isNotBlank()) {
+                    viewModel.createTask(projectId, newTaskTitle)
+                    newTaskTitle = ""
+                }
+            }) {
+                Text("Добавить")
+            }
+        }
+        Spacer(modifier = Modifier.height(12.dp))
+        LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            items(state.items) { task ->
+                TaskItem(task = task, onClick = { onTaskSelected(task.id) })
+            }
+        }
+    }
+}
+
+@Composable
+private fun FilterChip(label: String, selected: Boolean, onClick: () -> Unit) {
+    androidx.compose.material3.AssistChip(onClick = onClick, label = { Text(label) }, colors = if (selected) {
+        androidx.compose.material3.AssistChipDefaults.assistChipColors(
+            containerColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.2f)
+        )
+    } else {
+        androidx.compose.material3.AssistChipDefaults.assistChipColors()
+    })
+}
+
+@Composable
+private fun TaskItem(task: TaskSummaryDto, onClick: () -> Unit) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onClick() },
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(text = task.title, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(text = "Статус: ${task.status} | Приоритет: ${task.priority}")
+            task.assigneeName?.let { Text(text = "Исполнитель: $it") }
+            task.dueDate?.let { Text(text = "Срок: $it") }
+        }
+    }
+}

--- a/android/app/src/main/java/com/example/minitasker/ui/screen/tasks/TasksViewModel.kt
+++ b/android/app/src/main/java/com/example/minitasker/ui/screen/tasks/TasksViewModel.kt
@@ -1,0 +1,70 @@
+package com.example.minitasker.ui.screen.tasks
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.minitasker.data.model.TaskRequest
+import com.example.minitasker.data.model.TaskSummaryDto
+import com.example.minitasker.data.repository.NetworkResult
+import com.example.minitasker.data.repository.TaskRepository
+import com.example.minitasker.data.repository.safeCall
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+enum class TaskStatusFilter { ALL, TODO, IN_PROGRESS, DONE }
+
+enum class TaskPriorityFilter { ALL, LOW, MEDIUM, HIGH }
+
+data class TasksUiState(
+    val items: List<TaskSummaryDto> = emptyList(),
+    val loading: Boolean = false,
+    val error: String? = null,
+    val status: TaskStatusFilter = TaskStatusFilter.ALL,
+    val priority: TaskPriorityFilter = TaskPriorityFilter.ALL
+)
+
+class TasksViewModel(private val repository: TaskRepository) : ViewModel() {
+
+    private val _state = MutableStateFlow(TasksUiState())
+    val state: StateFlow<TasksUiState> = _state.asStateFlow()
+
+    fun loadTasks(projectId: Long) {
+        viewModelScope.launch {
+            _state.value = _state.value.copy(loading = true, error = null)
+            val statusFilter = if (_state.value.status == TaskStatusFilter.ALL) null else _state.value.status.name
+            val priorityFilter = if (_state.value.priority == TaskPriorityFilter.ALL) null else _state.value.priority.name
+            when (val result = safeCall {
+                repository.loadTasks(projectId, statusFilter, priorityFilter, null, 0, 100)
+            }) {
+                is NetworkResult.Success -> _state.value = _state.value.copy(
+                    loading = false,
+                    items = result.data.content
+                )
+                is NetworkResult.Error -> _state.value = _state.value.copy(loading = false, error = result.message)
+                NetworkResult.Loading -> _state.value = _state.value.copy(loading = true)
+            }
+        }
+    }
+
+    fun updateStatus(filter: TaskStatusFilter, projectId: Long) {
+        _state.value = _state.value.copy(status = filter)
+        loadTasks(projectId)
+    }
+
+    fun updatePriority(filter: TaskPriorityFilter, projectId: Long) {
+        _state.value = _state.value.copy(priority = filter)
+        loadTasks(projectId)
+    }
+
+    fun createTask(projectId: Long, title: String) {
+        viewModelScope.launch {
+            val request = TaskRequest(title, description = null, status = "TODO", priority = "MEDIUM", assigneeId = null, dueDate = null)
+            when (safeCall { repository.createTask(projectId, request) }) {
+                is NetworkResult.Success -> loadTasks(projectId)
+                is NetworkResult.Error -> _state.value = _state.value.copy(error = "Не удалось создать задачу")
+                NetworkResult.Loading -> Unit
+            }
+        }
+    }
+}

--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="md_theme_primary">#6750A4</color>
+    <color name="md_theme_onPrimary">#FFFFFF</color>
+    <color name="md_theme_secondary">#625B71</color>
+    <color name="md_theme_background">#FFFBFE</color>
+</resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">MiniTasker</string>
+</resources>

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -1,0 +1,4 @@
+plugins {
+    id("com.android.application") version "8.3.2" apply false
+    id("org.jetbrains.kotlin.android") version "1.9.23" apply false
+}

--- a/android/gradle/wrapper/gradle-wrapper.jar
+++ b/android/gradle/wrapper/gradle-wrapper.jar
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message><Key>distributions/gradle-8.6-wrapper.jar</Key><RequestId>76NMW01BXVNZAE35</RequestId><HostId>AkiDPrAFkGfLIyJpQXYcreQ50h20R8AxCK3NF3VSLscYmc3E/USdfSGm8q27mbNcZ+WOazqbR94=</HostId></Error>

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,5 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/android/gradlew
+++ b/android/gradlew
@@ -1,0 +1,20 @@
+#!/usr/bin/env sh
+
+# Copyright 2015 the original authors.
+# Gradle startup script for UN*X
+
+DIR="`dirname "$0"`"
+APP_BASE_NAME="`basename "$0"`"
+APP_HOME="`cd "$DIR"; pwd`"
+
+DEFAULT_JVM_OPTS=""
+
+CLASSPATH=$APP_HOME/gradle/wrapper/gradle-wrapper.jar
+
+if [ -n "$JAVA_HOME" ]; then
+    JAVACMD="$JAVA_HOME/bin/java"
+else
+    JAVACMD="java"
+fi
+
+exec "$JAVACMD" $DEFAULT_JVM_OPTS -classpath "$CLASSPATH" org.gradle.wrapper.GradleWrapperMain "$@"

--- a/android/gradlew.bat
+++ b/android/gradlew.bat
@@ -1,0 +1,12 @@
+@ECHO OFF
+SET DIR=%~dp0
+SET APP_HOME=%DIR:~0,-1%
+SET CLASSPATH=%APP_HOME%\gradle\wrapper\gradle-wrapper.jar
+
+IF EXIST "%JAVA_HOME%\bin\java.exe" (
+  SET JAVACMD="%JAVA_HOME%\bin\java.exe"
+) ELSE (
+  SET JAVACMD=java
+)
+
+%JAVACMD% -classpath "%CLASSPATH%" org.gradle.wrapper.GradleWrapperMain %*

--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -1,0 +1,18 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "MiniTasker"
+include(":app")

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>minitasker-backend</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>MiniTasker Backend</name>
+    <description>Spring Boot backend for MiniTasker application</description>
+
+    <properties>
+        <java.version>17</java.version>
+        <spring.boot.version>3.2.5</spring.boot.version>
+        <jjwt.version>0.11.5</jjwt.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring.boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-logging</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-api</artifactId>
+            <version>${jjwt.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-impl</artifactId>
+            <version>${jjwt.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-jackson</artifactId>
+            <version>${jjwt.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/backend/src/main/java/com/example/minitasker/MiniTaskerApplication.java
+++ b/backend/src/main/java/com/example/minitasker/MiniTaskerApplication.java
@@ -1,0 +1,14 @@
+package com.example.minitasker;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@SpringBootApplication
+@EnableAsync
+public class MiniTaskerApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(MiniTaskerApplication.class, args);
+    }
+}

--- a/backend/src/main/java/com/example/minitasker/config/StorageConfig.java
+++ b/backend/src/main/java/com/example/minitasker/config/StorageConfig.java
@@ -1,0 +1,27 @@
+package com.example.minitasker.config;
+
+import jakarta.annotation.PostConstruct;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class StorageConfig {
+
+    private static final Logger log = LoggerFactory.getLogger(StorageConfig.class);
+
+    @Value("${minitasker.storage.upload-dir}")
+    private String uploadDir;
+
+    @PostConstruct
+    public void init() throws IOException {
+        Path path = Paths.get(uploadDir).toAbsolutePath().normalize();
+        Files.createDirectories(path);
+        log.info("Using upload directory: {}", path);
+    }
+}

--- a/backend/src/main/java/com/example/minitasker/controller/AttachmentController.java
+++ b/backend/src/main/java/com/example/minitasker/controller/AttachmentController.java
@@ -1,0 +1,48 @@
+package com.example.minitasker.controller;
+
+import com.example.minitasker.dto.attachment.AttachmentResponse;
+import com.example.minitasker.service.AttachmentService;
+import java.io.IOException;
+import java.util.List;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/api")
+public class AttachmentController {
+
+    private final AttachmentService attachmentService;
+
+    public AttachmentController(AttachmentService attachmentService) {
+        this.attachmentService = attachmentService;
+    }
+
+    @GetMapping("/tasks/{taskId}/attachments")
+    public ResponseEntity<List<AttachmentResponse>> listAttachments(@PathVariable Long taskId) {
+        return ResponseEntity.ok(attachmentService.listAttachments(taskId));
+    }
+
+    @PostMapping(value = "/tasks/{taskId}/attachments", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<AttachmentResponse> uploadAttachment(@PathVariable Long taskId,
+                                                               @RequestParam("file") MultipartFile file)
+            throws IOException {
+        return ResponseEntity.ok(attachmentService.uploadAttachment(taskId, file));
+    }
+
+    @GetMapping("/attachments/{attachmentId}")
+    public ResponseEntity<Resource> downloadAttachment(@PathVariable Long attachmentId) {
+        Resource resource = attachmentService.downloadAttachment(attachmentId);
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=" + resource.getFilename())
+                .body(resource);
+    }
+}

--- a/backend/src/main/java/com/example/minitasker/controller/AuthController.java
+++ b/backend/src/main/java/com/example/minitasker/controller/AuthController.java
@@ -1,0 +1,40 @@
+package com.example.minitasker.controller;
+
+import com.example.minitasker.dto.auth.AuthResponse;
+import com.example.minitasker.dto.auth.LoginRequest;
+import com.example.minitasker.dto.auth.RegisterRequest;
+import com.example.minitasker.dto.auth.UserResponse;
+import com.example.minitasker.service.AuthService;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth")
+public class AuthController {
+
+    private final AuthService authService;
+
+    public AuthController(AuthService authService) {
+        this.authService = authService;
+    }
+
+    @PostMapping("/register")
+    public ResponseEntity<AuthResponse> register(@Valid @RequestBody RegisterRequest request) {
+        return ResponseEntity.ok(authService.register(request));
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<AuthResponse> login(@Valid @RequestBody LoginRequest request) {
+        return ResponseEntity.ok(authService.login(request));
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<UserResponse> me() {
+        return ResponseEntity.ok(authService.getCurrentUser());
+    }
+}

--- a/backend/src/main/java/com/example/minitasker/controller/CommentController.java
+++ b/backend/src/main/java/com/example/minitasker/controller/CommentController.java
@@ -1,0 +1,36 @@
+package com.example.minitasker.controller;
+
+import com.example.minitasker.dto.comment.CommentRequest;
+import com.example.minitasker.dto.comment.CommentResponse;
+import com.example.minitasker.service.CommentService;
+import jakarta.validation.Valid;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/tasks/{taskId}/comments")
+public class CommentController {
+
+    private final CommentService commentService;
+
+    public CommentController(CommentService commentService) {
+        this.commentService = commentService;
+    }
+
+    @GetMapping
+    public ResponseEntity<List<CommentResponse>> listComments(@PathVariable Long taskId) {
+        return ResponseEntity.ok(commentService.getComments(taskId));
+    }
+
+    @PostMapping
+    public ResponseEntity<CommentResponse> createComment(@PathVariable Long taskId,
+                                                         @Valid @RequestBody CommentRequest request) {
+        return ResponseEntity.ok(commentService.addComment(taskId, request));
+    }
+}

--- a/backend/src/main/java/com/example/minitasker/controller/ProjectController.java
+++ b/backend/src/main/java/com/example/minitasker/controller/ProjectController.java
@@ -1,0 +1,60 @@
+package com.example.minitasker.controller;
+
+import com.example.minitasker.dto.PageResponse;
+import com.example.minitasker.dto.project.ProjectRequest;
+import com.example.minitasker.dto.project.ProjectResponse;
+import com.example.minitasker.service.ProjectService;
+import jakarta.validation.Valid;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/projects")
+public class ProjectController {
+
+    private final ProjectService projectService;
+
+    public ProjectController(ProjectService projectService) {
+        this.projectService = projectService;
+    }
+
+    @GetMapping
+    public ResponseEntity<PageResponse<ProjectResponse>> listProjects(@RequestParam(required = false) String name,
+                                                                      @RequestParam(defaultValue = "0") int page,
+                                                                      @RequestParam(defaultValue = "20") int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        return ResponseEntity.ok(projectService.getProjects(name, pageable));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ProjectResponse> getProject(@PathVariable Long id) {
+        return ResponseEntity.ok(projectService.getProject(id));
+    }
+
+    @PostMapping
+    public ResponseEntity<ProjectResponse> createProject(@Valid @RequestBody ProjectRequest request) {
+        return ResponseEntity.ok(projectService.createProject(request));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<ProjectResponse> updateProject(@PathVariable Long id,
+                                                         @Valid @RequestBody ProjectRequest request) {
+        return ResponseEntity.ok(projectService.updateProject(id, request));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteProject(@PathVariable Long id) {
+        projectService.deleteProject(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/backend/src/main/java/com/example/minitasker/controller/ReportController.java
+++ b/backend/src/main/java/com/example/minitasker/controller/ReportController.java
@@ -1,0 +1,31 @@
+package com.example.minitasker.controller;
+
+import com.example.minitasker.service.ReportService;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/reports")
+public class ReportController {
+
+    private final ReportService reportService;
+
+    public ReportController(ReportService reportService) {
+        this.reportService = reportService;
+    }
+
+    @GetMapping(value = "/tasks/csv", produces = "text/csv")
+    public ResponseEntity<Resource> downloadCsv(@RequestParam Long projectId) {
+        Resource resource = reportService.generateTasksCsv(projectId);
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=" + resource.getFilename())
+                .contentType(MediaType.parseMediaType("text/csv"))
+                .body(resource);
+    }
+}

--- a/backend/src/main/java/com/example/minitasker/controller/StatsController.java
+++ b/backend/src/main/java/com/example/minitasker/controller/StatsController.java
@@ -1,0 +1,31 @@
+package com.example.minitasker.controller;
+
+import com.example.minitasker.dto.stats.KeyValueStat;
+import com.example.minitasker.service.StatsService;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/stats")
+public class StatsController {
+
+    private final StatsService statsService;
+
+    public StatsController(StatsService statsService) {
+        this.statsService = statsService;
+    }
+
+    @GetMapping("/tasks-by-status")
+    public ResponseEntity<List<KeyValueStat>> tasksByStatus(@RequestParam Long projectId) {
+        return ResponseEntity.ok(statsService.tasksByStatus(projectId));
+    }
+
+    @GetMapping("/tasks-by-priority")
+    public ResponseEntity<List<KeyValueStat>> tasksByPriority(@RequestParam Long projectId) {
+        return ResponseEntity.ok(statsService.tasksByPriority(projectId));
+    }
+}

--- a/backend/src/main/java/com/example/minitasker/controller/TaskController.java
+++ b/backend/src/main/java/com/example/minitasker/controller/TaskController.java
@@ -1,0 +1,65 @@
+package com.example.minitasker.controller;
+
+import com.example.minitasker.dto.PageResponse;
+import com.example.minitasker.dto.task.TaskRequest;
+import com.example.minitasker.dto.task.TaskResponse;
+import com.example.minitasker.dto.task.TaskSummary;
+import com.example.minitasker.service.TaskService;
+import jakarta.validation.Valid;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+public class TaskController {
+
+    private final TaskService taskService;
+
+    public TaskController(TaskService taskService) {
+        this.taskService = taskService;
+    }
+
+    @GetMapping("/projects/{projectId}/tasks")
+    public ResponseEntity<PageResponse<TaskSummary>> listTasks(@PathVariable Long projectId,
+                                                               @RequestParam(required = false) String status,
+                                                               @RequestParam(required = false) String priority,
+                                                               @RequestParam(required = false) Long assigneeId,
+                                                               @RequestParam(defaultValue = "0") int page,
+                                                               @RequestParam(defaultValue = "20") int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        return ResponseEntity.ok(taskService.getTasks(projectId, status, priority, assigneeId, pageable));
+    }
+
+    @PostMapping("/projects/{projectId}/tasks")
+    public ResponseEntity<TaskResponse> createTask(@PathVariable Long projectId,
+                                                   @Valid @RequestBody TaskRequest request) {
+        return ResponseEntity.ok(taskService.createTask(projectId, request));
+    }
+
+    @GetMapping("/tasks/{taskId}")
+    public ResponseEntity<TaskResponse> getTask(@PathVariable Long taskId) {
+        return ResponseEntity.ok(taskService.getTask(taskId));
+    }
+
+    @PutMapping("/tasks/{taskId}")
+    public ResponseEntity<TaskResponse> updateTask(@PathVariable Long taskId,
+                                                   @Valid @RequestBody TaskRequest request) {
+        return ResponseEntity.ok(taskService.updateTask(taskId, request));
+    }
+
+    @DeleteMapping("/tasks/{taskId}")
+    public ResponseEntity<Void> deleteTask(@PathVariable Long taskId) {
+        taskService.deleteTask(taskId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/backend/src/main/java/com/example/minitasker/controller/UserController.java
+++ b/backend/src/main/java/com/example/minitasker/controller/UserController.java
@@ -1,0 +1,53 @@
+package com.example.minitasker.controller;
+
+import com.example.minitasker.dto.PageResponse;
+import com.example.minitasker.dto.auth.UpdateUserRequest;
+import com.example.minitasker.dto.auth.UserResponse;
+import com.example.minitasker.service.UserService;
+import jakarta.validation.Valid;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/users")
+public class UserController {
+
+    private final UserService userService;
+
+    public UserController(UserService userService) {
+        this.userService = userService;
+    }
+
+    @GetMapping
+    public ResponseEntity<PageResponse<UserResponse>> listUsers(@RequestParam(defaultValue = "0") int page,
+                                                                @RequestParam(defaultValue = "20") int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        return ResponseEntity.ok(userService.listUsers(pageable));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<UserResponse> getUser(@PathVariable Long id) {
+        return ResponseEntity.ok(userService.getUser(id));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<UserResponse> updateUser(@PathVariable Long id,
+                                                   @Valid @RequestBody UpdateUserRequest request) {
+        return ResponseEntity.ok(userService.updateUser(id, request));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteUser(@PathVariable Long id) {
+        userService.deleteUser(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/backend/src/main/java/com/example/minitasker/dto/PageResponse.java
+++ b/backend/src/main/java/com/example/minitasker/dto/PageResponse.java
@@ -1,0 +1,62 @@
+package com.example.minitasker.dto;
+
+import java.util.List;
+
+public class PageResponse<T> {
+    private List<T> content;
+    private long totalElements;
+    private int totalPages;
+    private int page;
+    private int size;
+
+    public PageResponse() {
+    }
+
+    public PageResponse(List<T> content, long totalElements, int totalPages, int page, int size) {
+        this.content = content;
+        this.totalElements = totalElements;
+        this.totalPages = totalPages;
+        this.page = page;
+        this.size = size;
+    }
+
+    public List<T> getContent() {
+        return content;
+    }
+
+    public void setContent(List<T> content) {
+        this.content = content;
+    }
+
+    public long getTotalElements() {
+        return totalElements;
+    }
+
+    public void setTotalElements(long totalElements) {
+        this.totalElements = totalElements;
+    }
+
+    public int getTotalPages() {
+        return totalPages;
+    }
+
+    public void setTotalPages(int totalPages) {
+        this.totalPages = totalPages;
+    }
+
+    public int getPage() {
+        return page;
+    }
+
+    public void setPage(int page) {
+        this.page = page;
+    }
+
+    public int getSize() {
+        return size;
+    }
+
+    public void setSize(int size) {
+        this.size = size;
+    }
+}

--- a/backend/src/main/java/com/example/minitasker/dto/attachment/AttachmentResponse.java
+++ b/backend/src/main/java/com/example/minitasker/dto/attachment/AttachmentResponse.java
@@ -1,0 +1,60 @@
+package com.example.minitasker.dto.attachment;
+
+import java.time.OffsetDateTime;
+
+public class AttachmentResponse {
+    private Long id;
+    private Long taskId;
+    private String fileName;
+    private String contentType;
+    private String url;
+    private OffsetDateTime uploadedAt;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Long getTaskId() {
+        return taskId;
+    }
+
+    public void setTaskId(Long taskId) {
+        this.taskId = taskId;
+    }
+
+    public String getFileName() {
+        return fileName;
+    }
+
+    public void setFileName(String fileName) {
+        this.fileName = fileName;
+    }
+
+    public String getContentType() {
+        return contentType;
+    }
+
+    public void setContentType(String contentType) {
+        this.contentType = contentType;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public OffsetDateTime getUploadedAt() {
+        return uploadedAt;
+    }
+
+    public void setUploadedAt(OffsetDateTime uploadedAt) {
+        this.uploadedAt = uploadedAt;
+    }
+}

--- a/backend/src/main/java/com/example/minitasker/dto/auth/AuthResponse.java
+++ b/backend/src/main/java/com/example/minitasker/dto/auth/AuthResponse.java
@@ -1,0 +1,60 @@
+package com.example.minitasker.dto.auth;
+
+public class AuthResponse {
+    private String token;
+    private Long userId;
+    private String email;
+    private String fullName;
+    private String role;
+
+    public AuthResponse() {
+    }
+
+    public AuthResponse(String token, Long userId, String email, String fullName, String role) {
+        this.token = token;
+        this.userId = userId;
+        this.email = email;
+        this.fullName = fullName;
+        this.role = role;
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+    public void setToken(String token) {
+        this.token = token;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public void setUserId(Long userId) {
+        this.userId = userId;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getFullName() {
+        return fullName;
+    }
+
+    public void setFullName(String fullName) {
+        this.fullName = fullName;
+    }
+
+    public String getRole() {
+        return role;
+    }
+
+    public void setRole(String role) {
+        this.role = role;
+    }
+}

--- a/backend/src/main/java/com/example/minitasker/dto/auth/LoginRequest.java
+++ b/backend/src/main/java/com/example/minitasker/dto/auth/LoginRequest.java
@@ -1,0 +1,30 @@
+package com.example.minitasker.dto.auth;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public class LoginRequest {
+
+    @Email
+    @NotBlank
+    private String email;
+
+    @NotBlank
+    private String password;
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+}

--- a/backend/src/main/java/com/example/minitasker/dto/auth/RegisterRequest.java
+++ b/backend/src/main/java/com/example/minitasker/dto/auth/RegisterRequest.java
@@ -1,0 +1,43 @@
+package com.example.minitasker.dto.auth;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public class RegisterRequest {
+
+    @Email
+    @NotBlank
+    private String email;
+
+    @NotBlank
+    @Size(min = 6, max = 60)
+    private String password;
+
+    @NotBlank
+    private String fullName;
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public String getFullName() {
+        return fullName;
+    }
+
+    public void setFullName(String fullName) {
+        this.fullName = fullName;
+    }
+}

--- a/backend/src/main/java/com/example/minitasker/dto/auth/UpdateUserRequest.java
+++ b/backend/src/main/java/com/example/minitasker/dto/auth/UpdateUserRequest.java
@@ -1,0 +1,29 @@
+package com.example.minitasker.dto.auth;
+
+import com.example.minitasker.model.enums.Role;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public class UpdateUserRequest {
+    @NotBlank
+    private String fullName;
+
+    @NotNull
+    private Role role;
+
+    public String getFullName() {
+        return fullName;
+    }
+
+    public void setFullName(String fullName) {
+        this.fullName = fullName;
+    }
+
+    public Role getRole() {
+        return role;
+    }
+
+    public void setRole(Role role) {
+        this.role = role;
+    }
+}

--- a/backend/src/main/java/com/example/minitasker/dto/auth/UserResponse.java
+++ b/backend/src/main/java/com/example/minitasker/dto/auth/UserResponse.java
@@ -1,0 +1,51 @@
+package com.example.minitasker.dto.auth;
+
+import java.time.OffsetDateTime;
+
+public class UserResponse {
+    private Long id;
+    private String email;
+    private String fullName;
+    private String role;
+    private OffsetDateTime createdAt;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getFullName() {
+        return fullName;
+    }
+
+    public void setFullName(String fullName) {
+        this.fullName = fullName;
+    }
+
+    public String getRole() {
+        return role;
+    }
+
+    public void setRole(String role) {
+        this.role = role;
+    }
+
+    public OffsetDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(OffsetDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+}

--- a/backend/src/main/java/com/example/minitasker/dto/comment/CommentRequest.java
+++ b/backend/src/main/java/com/example/minitasker/dto/comment/CommentRequest.java
@@ -1,0 +1,18 @@
+package com.example.minitasker.dto.comment;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public class CommentRequest {
+    @NotBlank
+    @Size(max = 2000)
+    private String text;
+
+    public String getText() {
+        return text;
+    }
+
+    public void setText(String text) {
+        this.text = text;
+    }
+}

--- a/backend/src/main/java/com/example/minitasker/dto/comment/CommentResponse.java
+++ b/backend/src/main/java/com/example/minitasker/dto/comment/CommentResponse.java
@@ -1,0 +1,60 @@
+package com.example.minitasker.dto.comment;
+
+import java.time.OffsetDateTime;
+
+public class CommentResponse {
+    private Long id;
+    private Long taskId;
+    private Long authorId;
+    private String authorName;
+    private String text;
+    private OffsetDateTime createdAt;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Long getTaskId() {
+        return taskId;
+    }
+
+    public void setTaskId(Long taskId) {
+        this.taskId = taskId;
+    }
+
+    public Long getAuthorId() {
+        return authorId;
+    }
+
+    public void setAuthorId(Long authorId) {
+        this.authorId = authorId;
+    }
+
+    public String getAuthorName() {
+        return authorName;
+    }
+
+    public void setAuthorName(String authorName) {
+        this.authorName = authorName;
+    }
+
+    public String getText() {
+        return text;
+    }
+
+    public void setText(String text) {
+        this.text = text;
+    }
+
+    public OffsetDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(OffsetDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+}

--- a/backend/src/main/java/com/example/minitasker/dto/project/ProjectRequest.java
+++ b/backend/src/main/java/com/example/minitasker/dto/project/ProjectRequest.java
@@ -1,0 +1,29 @@
+package com.example.minitasker.dto.project;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public class ProjectRequest {
+    @NotBlank
+    @Size(max = 150)
+    private String name;
+
+    @Size(max = 2000)
+    private String description;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+}

--- a/backend/src/main/java/com/example/minitasker/dto/project/ProjectResponse.java
+++ b/backend/src/main/java/com/example/minitasker/dto/project/ProjectResponse.java
@@ -1,0 +1,60 @@
+package com.example.minitasker.dto.project;
+
+import java.time.OffsetDateTime;
+
+public class ProjectResponse {
+    private Long id;
+    private String name;
+    private String description;
+    private Long ownerId;
+    private String ownerName;
+    private OffsetDateTime createdAt;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public Long getOwnerId() {
+        return ownerId;
+    }
+
+    public void setOwnerId(Long ownerId) {
+        this.ownerId = ownerId;
+    }
+
+    public String getOwnerName() {
+        return ownerName;
+    }
+
+    public void setOwnerName(String ownerName) {
+        this.ownerName = ownerName;
+    }
+
+    public OffsetDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(OffsetDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+}

--- a/backend/src/main/java/com/example/minitasker/dto/stats/KeyValueStat.java
+++ b/backend/src/main/java/com/example/minitasker/dto/stats/KeyValueStat.java
@@ -1,0 +1,30 @@
+package com.example.minitasker.dto.stats;
+
+public class KeyValueStat {
+    private String key;
+    private long value;
+
+    public KeyValueStat() {
+    }
+
+    public KeyValueStat(String key, long value) {
+        this.key = key;
+        this.value = value;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    public long getValue() {
+        return value;
+    }
+
+    public void setValue(long value) {
+        this.value = value;
+    }
+}

--- a/backend/src/main/java/com/example/minitasker/dto/task/TaskRequest.java
+++ b/backend/src/main/java/com/example/minitasker/dto/task/TaskRequest.java
@@ -1,0 +1,75 @@
+package com.example.minitasker.dto.task;
+
+import com.example.minitasker.model.enums.TaskPriority;
+import com.example.minitasker.model.enums.TaskStatus;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.OffsetDateTime;
+
+public class TaskRequest {
+    @NotBlank
+    @Size(max = 150)
+    private String title;
+
+    @Size(max = 5000)
+    private String description;
+
+    @NotNull
+    private TaskStatus status;
+
+    @NotNull
+    private TaskPriority priority;
+
+    private Long assigneeId;
+
+    private OffsetDateTime dueDate;
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public TaskStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(TaskStatus status) {
+        this.status = status;
+    }
+
+    public TaskPriority getPriority() {
+        return priority;
+    }
+
+    public void setPriority(TaskPriority priority) {
+        this.priority = priority;
+    }
+
+    public Long getAssigneeId() {
+        return assigneeId;
+    }
+
+    public void setAssigneeId(Long assigneeId) {
+        this.assigneeId = assigneeId;
+    }
+
+    public OffsetDateTime getDueDate() {
+        return dueDate;
+    }
+
+    public void setDueDate(OffsetDateTime dueDate) {
+        this.dueDate = dueDate;
+    }
+}

--- a/backend/src/main/java/com/example/minitasker/dto/task/TaskResponse.java
+++ b/backend/src/main/java/com/example/minitasker/dto/task/TaskResponse.java
@@ -1,0 +1,213 @@
+package com.example.minitasker.dto.task;
+
+import com.example.minitasker.model.enums.TaskPriority;
+import com.example.minitasker.model.enums.TaskStatus;
+import java.time.OffsetDateTime;
+import java.util.List;
+
+public class TaskResponse {
+    private Long id;
+    private Long projectId;
+    private String title;
+    private String description;
+    private TaskStatus status;
+    private TaskPriority priority;
+    private Long assigneeId;
+    private String assigneeName;
+    private OffsetDateTime dueDate;
+    private OffsetDateTime createdAt;
+    private List<CommentResponse> comments;
+    private List<AttachmentResponse> attachments;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Long getProjectId() {
+        return projectId;
+    }
+
+    public void setProjectId(Long projectId) {
+        this.projectId = projectId;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public TaskStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(TaskStatus status) {
+        this.status = status;
+    }
+
+    public TaskPriority getPriority() {
+        return priority;
+    }
+
+    public void setPriority(TaskPriority priority) {
+        this.priority = priority;
+    }
+
+    public Long getAssigneeId() {
+        return assigneeId;
+    }
+
+    public void setAssigneeId(Long assigneeId) {
+        this.assigneeId = assigneeId;
+    }
+
+    public String getAssigneeName() {
+        return assigneeName;
+    }
+
+    public void setAssigneeName(String assigneeName) {
+        this.assigneeName = assigneeName;
+    }
+
+    public OffsetDateTime getDueDate() {
+        return dueDate;
+    }
+
+    public void setDueDate(OffsetDateTime dueDate) {
+        this.dueDate = dueDate;
+    }
+
+    public OffsetDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(OffsetDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public List<CommentResponse> getComments() {
+        return comments;
+    }
+
+    public void setComments(List<CommentResponse> comments) {
+        this.comments = comments;
+    }
+
+    public List<AttachmentResponse> getAttachments() {
+        return attachments;
+    }
+
+    public void setAttachments(List<AttachmentResponse> attachments) {
+        this.attachments = attachments;
+    }
+
+    public static class CommentResponse {
+        private Long id;
+        private Long authorId;
+        private String authorName;
+        private String text;
+        private OffsetDateTime createdAt;
+
+        public Long getId() {
+            return id;
+        }
+
+        public void setId(Long id) {
+            this.id = id;
+        }
+
+        public Long getAuthorId() {
+            return authorId;
+        }
+
+        public void setAuthorId(Long authorId) {
+            this.authorId = authorId;
+        }
+
+        public String getAuthorName() {
+            return authorName;
+        }
+
+        public void setAuthorName(String authorName) {
+            this.authorName = authorName;
+        }
+
+        public String getText() {
+            return text;
+        }
+
+        public void setText(String text) {
+            this.text = text;
+        }
+
+        public OffsetDateTime getCreatedAt() {
+            return createdAt;
+        }
+
+        public void setCreatedAt(OffsetDateTime createdAt) {
+            this.createdAt = createdAt;
+        }
+    }
+
+    public static class AttachmentResponse {
+        private Long id;
+        private String fileName;
+        private String contentType;
+        private String url;
+        private OffsetDateTime uploadedAt;
+
+        public Long getId() {
+            return id;
+        }
+
+        public void setId(Long id) {
+            this.id = id;
+        }
+
+        public String getFileName() {
+            return fileName;
+        }
+
+        public void setFileName(String fileName) {
+            this.fileName = fileName;
+        }
+
+        public String getContentType() {
+            return contentType;
+        }
+
+        public void setContentType(String contentType) {
+            this.contentType = contentType;
+        }
+
+        public String getUrl() {
+            return url;
+        }
+
+        public void setUrl(String url) {
+            this.url = url;
+        }
+
+        public OffsetDateTime getUploadedAt() {
+            return uploadedAt;
+        }
+
+        public void setUploadedAt(OffsetDateTime uploadedAt) {
+            this.uploadedAt = uploadedAt;
+        }
+    }
+}

--- a/backend/src/main/java/com/example/minitasker/dto/task/TaskSummary.java
+++ b/backend/src/main/java/com/example/minitasker/dto/task/TaskSummary.java
@@ -1,0 +1,62 @@
+package com.example.minitasker.dto.task;
+
+import com.example.minitasker.model.enums.TaskPriority;
+import com.example.minitasker.model.enums.TaskStatus;
+import java.time.OffsetDateTime;
+
+public class TaskSummary {
+    private Long id;
+    private String title;
+    private TaskStatus status;
+    private TaskPriority priority;
+    private OffsetDateTime dueDate;
+    private String assigneeName;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public TaskStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(TaskStatus status) {
+        this.status = status;
+    }
+
+    public TaskPriority getPriority() {
+        return priority;
+    }
+
+    public void setPriority(TaskPriority priority) {
+        this.priority = priority;
+    }
+
+    public OffsetDateTime getDueDate() {
+        return dueDate;
+    }
+
+    public void setDueDate(OffsetDateTime dueDate) {
+        this.dueDate = dueDate;
+    }
+
+    public String getAssigneeName() {
+        return assigneeName;
+    }
+
+    public void setAssigneeName(String assigneeName) {
+        this.assigneeName = assigneeName;
+    }
+}

--- a/backend/src/main/java/com/example/minitasker/exception/BadRequestException.java
+++ b/backend/src/main/java/com/example/minitasker/exception/BadRequestException.java
@@ -1,0 +1,11 @@
+package com.example.minitasker.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+public class BadRequestException extends RuntimeException {
+    public BadRequestException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/example/minitasker/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/example/minitasker/exception/GlobalExceptionHandler.java
@@ -1,0 +1,65 @@
+package com.example.minitasker.exception;
+
+import java.time.OffsetDateTime;
+import java.util.HashMap;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+@ControllerAdvice
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+
+    @Override
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(
+            MethodArgumentNotValidException ex,
+            HttpHeaders headers,
+            HttpStatusCode status,
+            WebRequest request) {
+        Map<String, Object> body = new HashMap<>();
+        body.put("timestamp", OffsetDateTime.now());
+        body.put("status", status.value());
+        body.put("error", "Validation failed");
+        Map<String, String> fieldErrors = new HashMap<>();
+        for (FieldError error : ex.getBindingResult().getFieldErrors()) {
+            fieldErrors.put(error.getField(), error.getDefaultMessage());
+        }
+        body.put("fieldErrors", fieldErrors);
+        return new ResponseEntity<>(body, headers, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(ResourceNotFoundException.class)
+    public ResponseEntity<Map<String, Object>> handleNotFound(ResourceNotFoundException ex) {
+        return buildErrorResponse(HttpStatus.NOT_FOUND, ex.getMessage());
+    }
+
+    @ExceptionHandler(BadRequestException.class)
+    public ResponseEntity<Map<String, Object>> handleBadRequest(BadRequestException ex) {
+        return buildErrorResponse(HttpStatus.BAD_REQUEST, ex.getMessage());
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<Map<String, Object>> handleGeneric(Exception ex) {
+        log.error("Unexpected error", ex);
+        return buildErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, "Internal server error");
+    }
+
+    private ResponseEntity<Map<String, Object>> buildErrorResponse(HttpStatus status, String message) {
+        Map<String, Object> body = new HashMap<>();
+        body.put("timestamp", OffsetDateTime.now());
+        body.put("status", status.value());
+        body.put("error", message);
+        return new ResponseEntity<>(body, status);
+    }
+}

--- a/backend/src/main/java/com/example/minitasker/exception/ResourceNotFoundException.java
+++ b/backend/src/main/java/com/example/minitasker/exception/ResourceNotFoundException.java
@@ -1,0 +1,11 @@
+package com.example.minitasker.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class ResourceNotFoundException extends RuntimeException {
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/example/minitasker/model/Attachment.java
+++ b/backend/src/main/java/com/example/minitasker/model/Attachment.java
@@ -1,0 +1,77 @@
+package com.example.minitasker.model;
+
+import jakarta.persistence.*;
+import java.time.OffsetDateTime;
+
+@Entity
+@Table(name = "attachments")
+public class Attachment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "task_id", nullable = false)
+    private Task task;
+
+    @Column(nullable = false)
+    private String fileName;
+
+    @Column(nullable = false)
+    private String contentType;
+
+    @Column(nullable = false)
+    private String filePath;
+
+    @Column(nullable = false)
+    private OffsetDateTime uploadedAt = OffsetDateTime.now();
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Task getTask() {
+        return task;
+    }
+
+    public void setTask(Task task) {
+        this.task = task;
+    }
+
+    public String getFileName() {
+        return fileName;
+    }
+
+    public void setFileName(String fileName) {
+        this.fileName = fileName;
+    }
+
+    public String getContentType() {
+        return contentType;
+    }
+
+    public void setContentType(String contentType) {
+        this.contentType = contentType;
+    }
+
+    public String getFilePath() {
+        return filePath;
+    }
+
+    public void setFilePath(String filePath) {
+        this.filePath = filePath;
+    }
+
+    public OffsetDateTime getUploadedAt() {
+        return uploadedAt;
+    }
+
+    public void setUploadedAt(OffsetDateTime uploadedAt) {
+        this.uploadedAt = uploadedAt;
+    }
+}

--- a/backend/src/main/java/com/example/minitasker/model/Comment.java
+++ b/backend/src/main/java/com/example/minitasker/model/Comment.java
@@ -1,0 +1,67 @@
+package com.example.minitasker.model;
+
+import jakarta.persistence.*;
+import java.time.OffsetDateTime;
+
+@Entity
+@Table(name = "comments")
+public class Comment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "task_id", nullable = false)
+    private Task task;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "author_id", nullable = false)
+    private User author;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String text;
+
+    @Column(nullable = false)
+    private OffsetDateTime createdAt = OffsetDateTime.now();
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Task getTask() {
+        return task;
+    }
+
+    public void setTask(Task task) {
+        this.task = task;
+    }
+
+    public User getAuthor() {
+        return author;
+    }
+
+    public void setAuthor(User author) {
+        this.author = author;
+    }
+
+    public String getText() {
+        return text;
+    }
+
+    public void setText(String text) {
+        this.text = text;
+    }
+
+    public OffsetDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(OffsetDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+}

--- a/backend/src/main/java/com/example/minitasker/model/Project.java
+++ b/backend/src/main/java/com/example/minitasker/model/Project.java
@@ -1,0 +1,71 @@
+package com.example.minitasker.model;
+
+import jakarta.persistence.*;
+import java.time.OffsetDateTime;
+import java.util.HashSet;
+import java.util.Set;
+
+@Entity
+@Table(name = "projects")
+public class Project {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "owner_id", nullable = false)
+    private User owner;
+
+    @Column(nullable = false)
+    private OffsetDateTime createdAt = OffsetDateTime.now();
+
+    @OneToMany(mappedBy = "project", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<Task> tasks = new HashSet<>();
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public User getOwner() {
+        return owner;
+    }
+
+    public void setOwner(User owner) {
+        this.owner = owner;
+    }
+
+    public OffsetDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(OffsetDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+}

--- a/backend/src/main/java/com/example/minitasker/model/Task.java
+++ b/backend/src/main/java/com/example/minitasker/model/Task.java
@@ -1,0 +1,122 @@
+package com.example.minitasker.model;
+
+import com.example.minitasker.model.enums.TaskPriority;
+import com.example.minitasker.model.enums.TaskStatus;
+import jakarta.persistence.*;
+import java.time.OffsetDateTime;
+import java.util.HashSet;
+import java.util.Set;
+
+@Entity
+@Table(name = "tasks")
+public class Task {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "project_id", nullable = false)
+    private Project project;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private TaskStatus status = TaskStatus.TODO;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private TaskPriority priority = TaskPriority.MEDIUM;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "assignee_id")
+    private User assignee;
+
+    private OffsetDateTime dueDate;
+
+    @Column(nullable = false)
+    private OffsetDateTime createdAt = OffsetDateTime.now();
+
+    @OneToMany(mappedBy = "task", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<Comment> comments = new HashSet<>();
+
+    @OneToMany(mappedBy = "task", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<Attachment> attachments = new HashSet<>();
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Project getProject() {
+        return project;
+    }
+
+    public void setProject(Project project) {
+        this.project = project;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public TaskStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(TaskStatus status) {
+        this.status = status;
+    }
+
+    public TaskPriority getPriority() {
+        return priority;
+    }
+
+    public void setPriority(TaskPriority priority) {
+        this.priority = priority;
+    }
+
+    public User getAssignee() {
+        return assignee;
+    }
+
+    public void setAssignee(User assignee) {
+        this.assignee = assignee;
+    }
+
+    public OffsetDateTime getDueDate() {
+        return dueDate;
+    }
+
+    public void setDueDate(OffsetDateTime dueDate) {
+        this.dueDate = dueDate;
+    }
+
+    public OffsetDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(OffsetDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+}

--- a/backend/src/main/java/com/example/minitasker/model/User.java
+++ b/backend/src/main/java/com/example/minitasker/model/User.java
@@ -1,0 +1,86 @@
+package com.example.minitasker.model;
+
+import com.example.minitasker.model.enums.Role;
+import jakarta.persistence.*;
+import java.time.OffsetDateTime;
+import java.util.HashSet;
+import java.util.Set;
+
+@Entity
+@Table(name = "users")
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(nullable = false)
+    private String passwordHash;
+
+    @Column(nullable = false)
+    private String fullName;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Role role = Role.USER;
+
+    @Column(nullable = false)
+    private OffsetDateTime createdAt = OffsetDateTime.now();
+
+    @OneToMany(mappedBy = "owner")
+    private Set<Project> ownedProjects = new HashSet<>();
+
+    @OneToMany(mappedBy = "assignee")
+    private Set<Task> assignedTasks = new HashSet<>();
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getPasswordHash() {
+        return passwordHash;
+    }
+
+    public void setPasswordHash(String passwordHash) {
+        this.passwordHash = passwordHash;
+    }
+
+    public String getFullName() {
+        return fullName;
+    }
+
+    public void setFullName(String fullName) {
+        this.fullName = fullName;
+    }
+
+    public Role getRole() {
+        return role;
+    }
+
+    public void setRole(Role role) {
+        this.role = role;
+    }
+
+    public OffsetDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(OffsetDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+}

--- a/backend/src/main/java/com/example/minitasker/model/enums/Role.java
+++ b/backend/src/main/java/com/example/minitasker/model/enums/Role.java
@@ -1,0 +1,6 @@
+package com.example.minitasker.model.enums;
+
+public enum Role {
+    USER,
+    ADMIN
+}

--- a/backend/src/main/java/com/example/minitasker/model/enums/TaskPriority.java
+++ b/backend/src/main/java/com/example/minitasker/model/enums/TaskPriority.java
@@ -1,0 +1,7 @@
+package com.example.minitasker.model.enums;
+
+public enum TaskPriority {
+    LOW,
+    MEDIUM,
+    HIGH
+}

--- a/backend/src/main/java/com/example/minitasker/model/enums/TaskStatus.java
+++ b/backend/src/main/java/com/example/minitasker/model/enums/TaskStatus.java
@@ -1,0 +1,7 @@
+package com.example.minitasker.model.enums;
+
+public enum TaskStatus {
+    TODO,
+    IN_PROGRESS,
+    DONE
+}

--- a/backend/src/main/java/com/example/minitasker/repository/AttachmentRepository.java
+++ b/backend/src/main/java/com/example/minitasker/repository/AttachmentRepository.java
@@ -1,0 +1,10 @@
+package com.example.minitasker.repository;
+
+import com.example.minitasker.model.Attachment;
+import com.example.minitasker.model.Task;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AttachmentRepository extends JpaRepository<Attachment, Long> {
+    List<Attachment> findByTask(Task task);
+}

--- a/backend/src/main/java/com/example/minitasker/repository/CommentRepository.java
+++ b/backend/src/main/java/com/example/minitasker/repository/CommentRepository.java
@@ -1,0 +1,10 @@
+package com.example.minitasker.repository;
+
+import com.example.minitasker.model.Comment;
+import com.example.minitasker.model.Task;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+    List<Comment> findByTaskOrderByCreatedAtAsc(Task task);
+}

--- a/backend/src/main/java/com/example/minitasker/repository/ProjectRepository.java
+++ b/backend/src/main/java/com/example/minitasker/repository/ProjectRepository.java
@@ -1,0 +1,17 @@
+package com.example.minitasker.repository;
+
+import com.example.minitasker.model.Project;
+import com.example.minitasker.model.User;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProjectRepository extends JpaRepository<Project, Long> {
+    Page<Project> findByOwner(User owner, Pageable pageable);
+    Page<Project> findByOwnerAndNameContainingIgnoreCase(User owner, String name, Pageable pageable);
+    Page<Project> findByNameContainingIgnoreCase(String name, Pageable pageable);
+    List<Project> findByOwner(User owner);
+    Optional<Project> findByIdAndOwner(Long id, User owner);
+}

--- a/backend/src/main/java/com/example/minitasker/repository/TaskRepository.java
+++ b/backend/src/main/java/com/example/minitasker/repository/TaskRepository.java
@@ -1,0 +1,24 @@
+package com.example.minitasker.repository;
+
+import com.example.minitasker.model.Project;
+import com.example.minitasker.model.Task;
+import com.example.minitasker.model.User;
+import com.example.minitasker.model.enums.TaskPriority;
+import com.example.minitasker.model.enums.TaskStatus;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+
+public interface TaskRepository extends JpaRepository<Task, Long>, JpaSpecificationExecutor<Task> {
+    Page<Task> findByProject(Project project, Pageable pageable);
+    List<Task> findByProject(Project project);
+    Optional<Task> findByIdAndProject(Long id, Project project);
+    Page<Task> findByProjectAndAssignee(Project project, User assignee, Pageable pageable);
+    long countByProjectAndStatus(Project project, TaskStatus status);
+    long countByProjectAndPriority(Project project, TaskPriority priority);
+    long countByProjectAndDueDateBefore(Project project, OffsetDateTime dueDate);
+}

--- a/backend/src/main/java/com/example/minitasker/repository/UserRepository.java
+++ b/backend/src/main/java/com/example/minitasker/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package com.example.minitasker.repository;
+
+import com.example.minitasker.model.User;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
+    boolean existsByEmail(String email);
+}

--- a/backend/src/main/java/com/example/minitasker/security/CustomUserDetails.java
+++ b/backend/src/main/java/com/example/minitasker/security/CustomUserDetails.java
@@ -1,0 +1,56 @@
+package com.example.minitasker.security;
+
+import com.example.minitasker.model.User;
+import java.util.Collection;
+import java.util.Collections;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+public class CustomUserDetails implements UserDetails {
+
+    private final User user;
+
+    public CustomUserDetails(User user) {
+        this.user = user;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.singleton(new SimpleGrantedAuthority("ROLE_" + user.getRole().name()));
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPasswordHash();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getEmail();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+    public User getUser() {
+        return user;
+    }
+}

--- a/backend/src/main/java/com/example/minitasker/security/CustomUserDetailsService.java
+++ b/backend/src/main/java/com/example/minitasker/security/CustomUserDetailsService.java
@@ -1,0 +1,25 @@
+package com.example.minitasker.security;
+
+import com.example.minitasker.model.User;
+import com.example.minitasker.repository.UserRepository;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    public CustomUserDetailsService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        User user = userRepository.findByEmail(username)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found: " + username));
+        return new CustomUserDetails(user);
+    }
+}

--- a/backend/src/main/java/com/example/minitasker/security/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/example/minitasker/security/JwtAuthenticationFilter.java
@@ -1,0 +1,54 @@
+package com.example.minitasker.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private static final Logger log = LoggerFactory.getLogger(JwtAuthenticationFilter.class);
+
+    private final JwtTokenProvider tokenProvider;
+    private final CustomUserDetailsService userDetailsService;
+
+    public JwtAuthenticationFilter(JwtTokenProvider tokenProvider, CustomUserDetailsService userDetailsService) {
+        this.tokenProvider = tokenProvider;
+        this.userDetailsService = userDetailsService;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        String header = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if (header != null && header.startsWith("Bearer ")) {
+            String token = header.substring(7);
+            try {
+                String username = tokenProvider.getUsernameFromToken(token);
+                if (username != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+                    UserDetails userDetails = userDetailsService.loadUserByUsername(username);
+                    if (tokenProvider.validateToken(token, userDetails)) {
+                        UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                                userDetails, null, userDetails.getAuthorities());
+                        authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                        SecurityContextHolder.getContext().setAuthentication(authentication);
+                    }
+                }
+            } catch (Exception ex) {
+                log.warn("JWT validation failed: {}", ex.getMessage());
+            }
+        }
+        filterChain.doFilter(request, response);
+    }
+}

--- a/backend/src/main/java/com/example/minitasker/security/JwtTokenProvider.java
+++ b/backend/src/main/java/com/example/minitasker/security/JwtTokenProvider.java
@@ -1,0 +1,65 @@
+package com.example.minitasker.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import java.security.Key;
+import java.time.OffsetDateTime;
+import java.util.Date;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtTokenProvider {
+
+    @Value("${minitasker.security.jwt-secret}")
+    private String jwtSecret;
+
+    @Value("${minitasker.security.jwt-expiration-minutes}")
+    private long expirationMinutes;
+
+    private Key key;
+
+    @PostConstruct
+    public void init() {
+        this.key = Keys.hmacShaKeyFor(jwtSecret.getBytes());
+    }
+
+    public String generateToken(UserDetails userDetails) {
+        Date now = new Date();
+        Date expiry = Date.from(OffsetDateTime.now().plusMinutes(expirationMinutes).toInstant());
+        return Jwts.builder()
+                .setSubject(userDetails.getUsername())
+                .setIssuedAt(now)
+                .setExpiration(expiry)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public String getUsernameFromToken(String token) {
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+        return claims.getSubject();
+    }
+
+    public boolean validateToken(String token, UserDetails userDetails) {
+        String username = getUsernameFromToken(token);
+        return username.equals(userDetails.getUsername()) && !isTokenExpired(token);
+    }
+
+    private boolean isTokenExpired(String token) {
+        Date expiration = Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .getExpiration();
+        return expiration.before(new Date());
+    }
+}

--- a/backend/src/main/java/com/example/minitasker/security/SecurityConfig.java
+++ b/backend/src/main/java/com/example/minitasker/security/SecurityConfig.java
@@ -1,0 +1,49 @@
+package com.example.minitasker.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableMethodSecurity
+public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    public SecurityConfig(JwtAuthenticationFilter jwtAuthenticationFilter) {
+        this.jwtAuthenticationFilter = jwtAuthenticationFilter;
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/auth/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/stats/**").authenticated()
+                        .requestMatchers("/api/users/**").hasRole("ADMIN")
+                        .anyRequest().authenticated())
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+        return configuration.getAuthenticationManager();
+    }
+}

--- a/backend/src/main/java/com/example/minitasker/service/AttachmentService.java
+++ b/backend/src/main/java/com/example/minitasker/service/AttachmentService.java
@@ -1,0 +1,13 @@
+package com.example.minitasker.service;
+
+import com.example.minitasker.dto.attachment.AttachmentResponse;
+import java.io.IOException;
+import java.util.List;
+import org.springframework.core.io.Resource;
+import org.springframework.web.multipart.MultipartFile;
+
+public interface AttachmentService {
+    List<AttachmentResponse> listAttachments(Long taskId);
+    AttachmentResponse uploadAttachment(Long taskId, MultipartFile file) throws IOException;
+    Resource downloadAttachment(Long attachmentId);
+}

--- a/backend/src/main/java/com/example/minitasker/service/AuthService.java
+++ b/backend/src/main/java/com/example/minitasker/service/AuthService.java
@@ -1,0 +1,12 @@
+package com.example.minitasker.service;
+
+import com.example.minitasker.dto.auth.AuthResponse;
+import com.example.minitasker.dto.auth.LoginRequest;
+import com.example.minitasker.dto.auth.RegisterRequest;
+import com.example.minitasker.dto.auth.UserResponse;
+
+public interface AuthService {
+    AuthResponse register(RegisterRequest request);
+    AuthResponse login(LoginRequest request);
+    UserResponse getCurrentUser();
+}

--- a/backend/src/main/java/com/example/minitasker/service/CommentService.java
+++ b/backend/src/main/java/com/example/minitasker/service/CommentService.java
@@ -1,0 +1,10 @@
+package com.example.minitasker.service;
+
+import com.example.minitasker.dto.comment.CommentRequest;
+import com.example.minitasker.dto.comment.CommentResponse;
+import java.util.List;
+
+public interface CommentService {
+    List<CommentResponse> getComments(Long taskId);
+    CommentResponse addComment(Long taskId, CommentRequest request);
+}

--- a/backend/src/main/java/com/example/minitasker/service/ProjectService.java
+++ b/backend/src/main/java/com/example/minitasker/service/ProjectService.java
@@ -1,0 +1,14 @@
+package com.example.minitasker.service;
+
+import com.example.minitasker.dto.PageResponse;
+import com.example.minitasker.dto.project.ProjectRequest;
+import com.example.minitasker.dto.project.ProjectResponse;
+import org.springframework.data.domain.Pageable;
+
+public interface ProjectService {
+    PageResponse<ProjectResponse> getProjects(String nameFilter, Pageable pageable);
+    ProjectResponse getProject(Long id);
+    ProjectResponse createProject(ProjectRequest request);
+    ProjectResponse updateProject(Long id, ProjectRequest request);
+    void deleteProject(Long id);
+}

--- a/backend/src/main/java/com/example/minitasker/service/ReportService.java
+++ b/backend/src/main/java/com/example/minitasker/service/ReportService.java
@@ -1,0 +1,7 @@
+package com.example.minitasker.service;
+
+import org.springframework.core.io.Resource;
+
+public interface ReportService {
+    Resource generateTasksCsv(Long projectId);
+}

--- a/backend/src/main/java/com/example/minitasker/service/StatsService.java
+++ b/backend/src/main/java/com/example/minitasker/service/StatsService.java
@@ -1,0 +1,9 @@
+package com.example.minitasker.service;
+
+import com.example.minitasker.dto.stats.KeyValueStat;
+import java.util.List;
+
+public interface StatsService {
+    List<KeyValueStat> tasksByStatus(Long projectId);
+    List<KeyValueStat> tasksByPriority(Long projectId);
+}

--- a/backend/src/main/java/com/example/minitasker/service/TaskService.java
+++ b/backend/src/main/java/com/example/minitasker/service/TaskService.java
@@ -1,0 +1,15 @@
+package com.example.minitasker.service;
+
+import com.example.minitasker.dto.PageResponse;
+import com.example.minitasker.dto.task.TaskRequest;
+import com.example.minitasker.dto.task.TaskResponse;
+import com.example.minitasker.dto.task.TaskSummary;
+import org.springframework.data.domain.Pageable;
+
+public interface TaskService {
+    PageResponse<TaskSummary> getTasks(Long projectId, String status, String priority, Long assigneeId, Pageable pageable);
+    TaskResponse getTask(Long id);
+    TaskResponse createTask(Long projectId, TaskRequest request);
+    TaskResponse updateTask(Long taskId, TaskRequest request);
+    void deleteTask(Long id);
+}

--- a/backend/src/main/java/com/example/minitasker/service/UserService.java
+++ b/backend/src/main/java/com/example/minitasker/service/UserService.java
@@ -1,0 +1,13 @@
+package com.example.minitasker.service;
+
+import com.example.minitasker.dto.PageResponse;
+import com.example.minitasker.dto.auth.UpdateUserRequest;
+import com.example.minitasker.dto.auth.UserResponse;
+import org.springframework.data.domain.Pageable;
+
+public interface UserService {
+    PageResponse<UserResponse> listUsers(Pageable pageable);
+    UserResponse getUser(Long id);
+    UserResponse updateUser(Long id, UpdateUserRequest request);
+    void deleteUser(Long id);
+}

--- a/backend/src/main/java/com/example/minitasker/service/impl/AttachmentServiceImpl.java
+++ b/backend/src/main/java/com/example/minitasker/service/impl/AttachmentServiceImpl.java
@@ -1,0 +1,109 @@
+package com.example.minitasker.service.impl;
+
+import com.example.minitasker.dto.attachment.AttachmentResponse;
+import com.example.minitasker.exception.BadRequestException;
+import com.example.minitasker.exception.ResourceNotFoundException;
+import com.example.minitasker.model.Attachment;
+import com.example.minitasker.model.Task;
+import com.example.minitasker.model.User;
+import com.example.minitasker.model.enums.Role;
+import com.example.minitasker.repository.AttachmentRepository;
+import com.example.minitasker.repository.TaskRepository;
+import com.example.minitasker.service.AttachmentService;
+import com.example.minitasker.util.SecurityUtils;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.Resource;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@Transactional
+public class AttachmentServiceImpl implements AttachmentService {
+
+    private final AttachmentRepository attachmentRepository;
+    private final TaskRepository taskRepository;
+    private final Path storagePath;
+
+    public AttachmentServiceImpl(AttachmentRepository attachmentRepository,
+                                 TaskRepository taskRepository,
+                                 @Value("${minitasker.storage.upload-dir}") String uploadDir) {
+        this.attachmentRepository = attachmentRepository;
+        this.taskRepository = taskRepository;
+        this.storagePath = Paths.get(uploadDir).toAbsolutePath().normalize();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<AttachmentResponse> listAttachments(Long taskId) {
+        Task task = loadTask(taskId);
+        return attachmentRepository.findByTask(task).stream()
+                .map(this::mapToDto)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public AttachmentResponse uploadAttachment(Long taskId, MultipartFile file) throws IOException {
+        if (file.isEmpty() || StringUtils.isBlank(file.getOriginalFilename())) {
+            throw new BadRequestException("File is empty");
+        }
+        Task task = loadTask(taskId);
+        String filename = System.currentTimeMillis() + "_" + file.getOriginalFilename();
+        Path destination = storagePath.resolve(filename);
+        Files.copy(file.getInputStream(), destination);
+        Attachment attachment = new Attachment();
+        attachment.setTask(task);
+        attachment.setFileName(file.getOriginalFilename());
+        attachment.setContentType(file.getContentType() != null ? file.getContentType() : "application/octet-stream");
+        attachment.setFilePath(destination.toString());
+        Attachment saved = attachmentRepository.save(attachment);
+        return mapToDto(saved);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Resource downloadAttachment(Long attachmentId) {
+        Attachment attachment = attachmentRepository.findById(attachmentId)
+                .orElseThrow(() -> new ResourceNotFoundException("Attachment not found"));
+        ensureTaskAccess(attachment.getTask());
+        return new FileSystemResource(Paths.get(attachment.getFilePath()));
+    }
+
+    private Task loadTask(Long id) {
+        Task task = taskRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Task not found"));
+        ensureTaskAccess(task);
+        return task;
+    }
+
+    private void ensureTaskAccess(Task task) {
+        User current = SecurityUtils.getCurrentUser();
+        if (current.getRole() == Role.ADMIN) {
+            return;
+        }
+        boolean owner = task.getProject().getOwner().getId().equals(current.getId());
+        boolean assigned = task.getAssignee() != null && task.getAssignee().getId().equals(current.getId());
+        if (!owner && !assigned) {
+            throw new ResourceNotFoundException("Task not found");
+        }
+    }
+
+    private AttachmentResponse mapToDto(Attachment attachment) {
+        AttachmentResponse response = new AttachmentResponse();
+        response.setId(attachment.getId());
+        response.setTaskId(attachment.getTask().getId());
+        response.setFileName(attachment.getFileName());
+        response.setContentType(attachment.getContentType());
+        response.setUrl("/api/attachments/" + attachment.getId());
+        response.setUploadedAt(attachment.getUploadedAt());
+        return response;
+    }
+}

--- a/backend/src/main/java/com/example/minitasker/service/impl/AuthServiceImpl.java
+++ b/backend/src/main/java/com/example/minitasker/service/impl/AuthServiceImpl.java
@@ -1,0 +1,93 @@
+package com.example.minitasker.service.impl;
+
+import com.example.minitasker.dto.auth.AuthResponse;
+import com.example.minitasker.dto.auth.LoginRequest;
+import com.example.minitasker.dto.auth.RegisterRequest;
+import com.example.minitasker.dto.auth.UserResponse;
+import com.example.minitasker.exception.BadRequestException;
+import com.example.minitasker.model.User;
+import com.example.minitasker.model.enums.Role;
+import com.example.minitasker.repository.UserRepository;
+import com.example.minitasker.security.CustomUserDetails;
+import com.example.minitasker.security.JwtTokenProvider;
+import com.example.minitasker.service.AuthService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class AuthServiceImpl implements AuthService {
+
+    private static final Logger log = LoggerFactory.getLogger(AuthServiceImpl.class);
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final AuthenticationManager authenticationManager;
+    private final JwtTokenProvider tokenProvider;
+
+    public AuthServiceImpl(UserRepository userRepository,
+                           PasswordEncoder passwordEncoder,
+                           AuthenticationManager authenticationManager,
+                           JwtTokenProvider tokenProvider) {
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+        this.authenticationManager = authenticationManager;
+        this.tokenProvider = tokenProvider;
+    }
+
+    @Override
+    public AuthResponse register(RegisterRequest request) {
+        if (userRepository.existsByEmail(request.getEmail())) {
+            throw new BadRequestException("Email already registered");
+        }
+        User user = new User();
+        user.setEmail(request.getEmail().toLowerCase());
+        user.setPasswordHash(passwordEncoder.encode(request.getPassword()));
+        user.setFullName(request.getFullName());
+        user.setRole(Role.USER);
+        userRepository.save(user);
+        log.info("New user registered: {}", user.getEmail());
+        CustomUserDetails userDetails = new CustomUserDetails(user);
+        String token = tokenProvider.generateToken(userDetails);
+        return new AuthResponse(token, user.getId(), user.getEmail(), user.getFullName(), user.getRole().name());
+    }
+
+    @Override
+    public AuthResponse login(LoginRequest request) {
+        Authentication authentication = authenticationManager.authenticate(
+                new UsernamePasswordAuthenticationToken(request.getEmail(), request.getPassword()));
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+        String token = tokenProvider.generateToken(userDetails);
+        User user = userDetails.getUser();
+        log.info("User logged in: {}", user.getEmail());
+        return new AuthResponse(token, user.getId(), user.getEmail(), user.getFullName(), user.getRole().name());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public UserResponse getCurrentUser() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !(authentication.getPrincipal() instanceof CustomUserDetails userDetails)) {
+            throw new BadRequestException("No authenticated user");
+        }
+        return mapToUserResponse(userDetails.getUser());
+    }
+
+    private UserResponse mapToUserResponse(User user) {
+        UserResponse response = new UserResponse();
+        response.setId(user.getId());
+        response.setEmail(user.getEmail());
+        response.setFullName(user.getFullName());
+        response.setRole(user.getRole().name());
+        response.setCreatedAt(user.getCreatedAt());
+        return response;
+    }
+}

--- a/backend/src/main/java/com/example/minitasker/service/impl/CommentServiceImpl.java
+++ b/backend/src/main/java/com/example/minitasker/service/impl/CommentServiceImpl.java
@@ -1,0 +1,76 @@
+package com.example.minitasker.service.impl;
+
+import com.example.minitasker.dto.comment.CommentRequest;
+import com.example.minitasker.dto.comment.CommentResponse;
+import com.example.minitasker.exception.ResourceNotFoundException;
+import com.example.minitasker.model.Comment;
+import com.example.minitasker.model.Task;
+import com.example.minitasker.model.User;
+import com.example.minitasker.model.enums.Role;
+import com.example.minitasker.repository.CommentRepository;
+import com.example.minitasker.repository.TaskRepository;
+import com.example.minitasker.service.CommentService;
+import com.example.minitasker.util.SecurityUtils;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class CommentServiceImpl implements CommentService {
+
+    private final CommentRepository commentRepository;
+    private final TaskRepository taskRepository;
+
+    public CommentServiceImpl(CommentRepository commentRepository, TaskRepository taskRepository) {
+        this.commentRepository = commentRepository;
+        this.taskRepository = taskRepository;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<CommentResponse> getComments(Long taskId) {
+        Task task = loadTask(taskId);
+        return commentRepository.findByTaskOrderByCreatedAtAsc(task).stream()
+                .map(this::mapToDto)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public CommentResponse addComment(Long taskId, CommentRequest request) {
+        Task task = loadTask(taskId);
+        User current = SecurityUtils.getCurrentUser();
+        Comment comment = new Comment();
+        comment.setTask(task);
+        comment.setAuthor(current);
+        comment.setText(request.getText());
+        return mapToDto(commentRepository.save(comment));
+    }
+
+    private Task loadTask(Long id) {
+        Task task = taskRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Task not found"));
+        User current = SecurityUtils.getCurrentUser();
+        if (current.getRole() == Role.ADMIN) {
+            return task;
+        }
+        boolean owner = task.getProject().getOwner().getId().equals(current.getId());
+        boolean assigned = task.getAssignee() != null && task.getAssignee().getId().equals(current.getId());
+        if (!owner && !assigned) {
+            throw new ResourceNotFoundException("Task not found");
+        }
+        return task;
+    }
+
+    private CommentResponse mapToDto(Comment comment) {
+        CommentResponse response = new CommentResponse();
+        response.setId(comment.getId());
+        response.setTaskId(comment.getTask().getId());
+        response.setAuthorId(comment.getAuthor().getId());
+        response.setAuthorName(comment.getAuthor().getFullName());
+        response.setText(comment.getText());
+        response.setCreatedAt(comment.getCreatedAt());
+        return response;
+    }
+}

--- a/backend/src/main/java/com/example/minitasker/service/impl/ProjectServiceImpl.java
+++ b/backend/src/main/java/com/example/minitasker/service/impl/ProjectServiceImpl.java
@@ -1,0 +1,118 @@
+package com.example.minitasker.service.impl;
+
+import com.example.minitasker.dto.PageResponse;
+import com.example.minitasker.dto.project.ProjectRequest;
+import com.example.minitasker.dto.project.ProjectResponse;
+import com.example.minitasker.exception.ResourceNotFoundException;
+import com.example.minitasker.model.Project;
+import com.example.minitasker.model.User;
+import com.example.minitasker.model.enums.Role;
+import com.example.minitasker.repository.ProjectRepository;
+import com.example.minitasker.repository.UserRepository;
+import com.example.minitasker.service.ProjectService;
+import com.example.minitasker.util.SecurityUtils;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class ProjectServiceImpl implements ProjectService {
+
+    private static final Logger log = LoggerFactory.getLogger(ProjectServiceImpl.class);
+
+    private final ProjectRepository projectRepository;
+    private final UserRepository userRepository;
+
+    public ProjectServiceImpl(ProjectRepository projectRepository, UserRepository userRepository) {
+        this.projectRepository = projectRepository;
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public PageResponse<ProjectResponse> getProjects(String nameFilter, Pageable pageable) {
+        User current = SecurityUtils.getCurrentUser();
+        Page<Project> page;
+        if (current.getRole() == Role.ADMIN) {
+            if (nameFilter != null && !nameFilter.isBlank()) {
+                page = projectRepository.findByNameContainingIgnoreCase(nameFilter, pageable);
+            } else {
+                page = projectRepository.findAll(pageable);
+            }
+        } else {
+            if (nameFilter != null && !nameFilter.isBlank()) {
+                page = projectRepository.findByOwnerAndNameContainingIgnoreCase(current, nameFilter, pageable);
+            } else {
+                page = projectRepository.findByOwner(current, pageable);
+            }
+        }
+        return new PageResponse<>(
+                page.map(this::mapToDto).getContent(),
+                page.getTotalElements(),
+                page.getTotalPages(),
+                page.getNumber(),
+                page.getSize());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public ProjectResponse getProject(Long id) {
+        Project project = loadProjectForCurrentUser(id);
+        return mapToDto(project);
+    }
+
+    @Override
+    public ProjectResponse createProject(ProjectRequest request) {
+        User current = SecurityUtils.getCurrentUser();
+        Project project = new Project();
+        project.setName(request.getName());
+        project.setDescription(request.getDescription());
+        project.setOwner(current);
+        Project saved = projectRepository.save(project);
+        log.info("Project created: {} by {}", saved.getId(), current.getEmail());
+        return mapToDto(saved);
+    }
+
+    @Override
+    public ProjectResponse updateProject(Long id, ProjectRequest request) {
+        Project project = loadProjectForCurrentUser(id);
+        project.setName(request.getName());
+        project.setDescription(request.getDescription());
+        Project updated = projectRepository.save(project);
+        log.info("Project updated: {}", updated.getId());
+        return mapToDto(updated);
+    }
+
+    @Override
+    public void deleteProject(Long id) {
+        Project project = loadProjectForCurrentUser(id);
+        projectRepository.delete(project);
+        log.info("Project deleted: {}", project.getId());
+    }
+
+    private Project loadProjectForCurrentUser(Long id) {
+        User current = SecurityUtils.getCurrentUser();
+        if (current.getRole() == Role.ADMIN) {
+            return projectRepository.findById(id)
+                    .orElseThrow(() -> new ResourceNotFoundException("Project not found"));
+        }
+        return projectRepository.findByIdAndOwner(id, current)
+                .orElseThrow(() -> new ResourceNotFoundException("Project not found"));
+    }
+
+    private ProjectResponse mapToDto(Project project) {
+        ProjectResponse response = new ProjectResponse();
+        response.setId(project.getId());
+        response.setName(project.getName());
+        response.setDescription(project.getDescription());
+        response.setOwnerId(project.getOwner().getId());
+        response.setOwnerName(project.getOwner().getFullName());
+        response.setCreatedAt(project.getCreatedAt());
+        return response;
+    }
+}

--- a/backend/src/main/java/com/example/minitasker/service/impl/ReportServiceImpl.java
+++ b/backend/src/main/java/com/example/minitasker/service/impl/ReportServiceImpl.java
@@ -1,0 +1,80 @@
+package com.example.minitasker.service.impl;
+
+import com.example.minitasker.exception.ResourceNotFoundException;
+import com.example.minitasker.model.Project;
+import com.example.minitasker.model.Task;
+import com.example.minitasker.model.enums.Role;
+import com.example.minitasker.repository.ProjectRepository;
+import com.example.minitasker.repository.TaskRepository;
+import com.example.minitasker.service.ReportService;
+import com.example.minitasker.util.SecurityUtils;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import org.springframework.core.io.InputStreamResource;
+import org.springframework.core.io.Resource;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class ReportServiceImpl implements ReportService {
+
+    private final ProjectRepository projectRepository;
+    private final TaskRepository taskRepository;
+
+    public ReportServiceImpl(ProjectRepository projectRepository, TaskRepository taskRepository) {
+        this.projectRepository = projectRepository;
+        this.taskRepository = taskRepository;
+    }
+
+    @Override
+    public Resource generateTasksCsv(Long projectId) {
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(() -> new ResourceNotFoundException("Project not found"));
+        ensureAccess(project);
+        List<Task> tasks = taskRepository.findByProject(project);
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        try (PrintWriter writer = new PrintWriter(outputStream, true, StandardCharsets.UTF_8)) {
+            writer.println("Task ID,Title,Status,Priority,Assignee,Due Date");
+            DateTimeFormatter formatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+            tasks.forEach(task -> writer.printf("%d,%s,%s,%s,%s,%s%n",
+                    task.getId(),
+                    escape(task.getTitle()),
+                    task.getStatus().name(),
+                    task.getPriority().name(),
+                    task.getAssignee() != null ? escape(task.getAssignee().getFullName()) : "",
+                    task.getDueDate() != null ? task.getDueDate().format(formatter) : ""));
+        }
+        return new InputStreamResource(new ByteArrayInputStream(outputStream.toByteArray())) {
+            @Override
+            public String getFilename() {
+                return "tasks_project_" + projectId + ".csv";
+            }
+        };
+    }
+
+    private void ensureAccess(Project project) {
+        var current = SecurityUtils.getCurrentUser();
+        if (current.getRole() == Role.ADMIN) {
+            return;
+        }
+        boolean owner = project.getOwner().getId().equals(current.getId());
+        boolean assigned = project.getTasks().stream()
+                .anyMatch(task -> task.getAssignee() != null && task.getAssignee().getId().equals(current.getId()));
+        if (!owner && !assigned) {
+            throw new ResourceNotFoundException("Project not found");
+        }
+    }
+
+    private String escape(String value) {
+        if (value == null) {
+            return "";
+        }
+        String sanitized = value.replace("\"", "\"\"");
+        return '"' + sanitized + '"';
+    }
+}

--- a/backend/src/main/java/com/example/minitasker/service/impl/StatsServiceImpl.java
+++ b/backend/src/main/java/com/example/minitasker/service/impl/StatsServiceImpl.java
@@ -1,0 +1,75 @@
+package com.example.minitasker.service.impl;
+
+import com.example.minitasker.dto.stats.KeyValueStat;
+import com.example.minitasker.exception.ResourceNotFoundException;
+import com.example.minitasker.model.Project;
+import com.example.minitasker.model.Task;
+import com.example.minitasker.model.User;
+import com.example.minitasker.model.enums.Role;
+import com.example.minitasker.model.enums.TaskPriority;
+import com.example.minitasker.model.enums.TaskStatus;
+import com.example.minitasker.repository.ProjectRepository;
+import com.example.minitasker.repository.TaskRepository;
+import com.example.minitasker.service.StatsService;
+import com.example.minitasker.util.SecurityUtils;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class StatsServiceImpl implements StatsService {
+
+    private final ProjectRepository projectRepository;
+    private final TaskRepository taskRepository;
+
+    public StatsServiceImpl(ProjectRepository projectRepository, TaskRepository taskRepository) {
+        this.projectRepository = projectRepository;
+        this.taskRepository = taskRepository;
+    }
+
+    @Override
+    public List<KeyValueStat> tasksByStatus(Long projectId) {
+        Project project = loadProject(projectId);
+        List<KeyValueStat> stats = new ArrayList<>();
+        for (TaskStatus status : TaskStatus.values()) {
+            long count = taskRepository.countByProjectAndStatus(project, status);
+            stats.add(new KeyValueStat(status.name(), count));
+        }
+        return stats;
+    }
+
+    @Override
+    public List<KeyValueStat> tasksByPriority(Long projectId) {
+        Project project = loadProject(projectId);
+        List<KeyValueStat> stats = new ArrayList<>();
+        for (TaskPriority priority : TaskPriority.values()) {
+            long count = taskRepository.countByProjectAndPriority(project, priority);
+            stats.add(new KeyValueStat(priority.name(), count));
+        }
+        return stats;
+    }
+
+    private Project loadProject(Long projectId) {
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(() -> new ResourceNotFoundException("Project not found"));
+        ensureAccess(project);
+        return project;
+    }
+
+    private void ensureAccess(Project project) {
+        User current = SecurityUtils.getCurrentUser();
+        if (current.getRole() == Role.ADMIN) {
+            return;
+        }
+        boolean owner = project.getOwner().getId().equals(current.getId());
+        boolean assigned = project.getTasks().stream()
+                .map(Task::getAssignee)
+                .filter(a -> a != null)
+                .anyMatch(a -> a.getId().equals(current.getId()));
+        if (!owner && !assigned) {
+            throw new ResourceNotFoundException("Project not found");
+        }
+    }
+}

--- a/backend/src/main/java/com/example/minitasker/service/impl/TaskServiceImpl.java
+++ b/backend/src/main/java/com/example/minitasker/service/impl/TaskServiceImpl.java
@@ -1,0 +1,215 @@
+package com.example.minitasker.service.impl;
+
+import com.example.minitasker.dto.PageResponse;
+import com.example.minitasker.dto.comment.CommentResponse;
+import com.example.minitasker.dto.task.TaskRequest;
+import com.example.minitasker.dto.task.TaskResponse;
+import com.example.minitasker.dto.task.TaskSummary;
+import com.example.minitasker.exception.BadRequestException;
+import com.example.minitasker.exception.ResourceNotFoundException;
+import com.example.minitasker.model.Comment;
+import com.example.minitasker.model.Project;
+import com.example.minitasker.model.Task;
+import com.example.minitasker.model.User;
+import com.example.minitasker.model.enums.Role;
+import com.example.minitasker.model.enums.TaskPriority;
+import com.example.minitasker.model.enums.TaskStatus;
+import com.example.minitasker.repository.CommentRepository;
+import com.example.minitasker.repository.ProjectRepository;
+import com.example.minitasker.repository.TaskRepository;
+import com.example.minitasker.repository.UserRepository;
+import com.example.minitasker.service.TaskService;
+import com.example.minitasker.util.SecurityUtils;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class TaskServiceImpl implements TaskService {
+
+    private static final Logger log = LoggerFactory.getLogger(TaskServiceImpl.class);
+
+    private final TaskRepository taskRepository;
+    private final ProjectRepository projectRepository;
+    private final UserRepository userRepository;
+    private final CommentRepository commentRepository;
+
+    public TaskServiceImpl(TaskRepository taskRepository,
+                           ProjectRepository projectRepository,
+                           UserRepository userRepository,
+                           CommentRepository commentRepository) {
+        this.taskRepository = taskRepository;
+        this.projectRepository = projectRepository;
+        this.userRepository = userRepository;
+        this.commentRepository = commentRepository;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public PageResponse<TaskSummary> getTasks(Long projectId, String status, String priority, Long assigneeId, Pageable pageable) {
+        Project project = loadProjectForCurrentUser(projectId);
+        Specification<Task> spec = Specification.where((root, query, cb) -> cb.equal(root.get("project"), project));
+        if (status != null && !status.isBlank()) {
+            TaskStatus taskStatus;
+            try {
+                taskStatus = TaskStatus.valueOf(status);
+            } catch (IllegalArgumentException ex) {
+                throw new BadRequestException("Invalid status value: " + status);
+            }
+            spec = spec.and((root, query, cb) -> cb.equal(root.get("status"), taskStatus));
+        }
+        if (priority != null && !priority.isBlank()) {
+            TaskPriority taskPriority;
+            try {
+                taskPriority = TaskPriority.valueOf(priority);
+            } catch (IllegalArgumentException ex) {
+                throw new BadRequestException("Invalid priority value: " + priority);
+            }
+            spec = spec.and((root, query, cb) -> cb.equal(root.get("priority"), taskPriority));
+        }
+        if (assigneeId != null) {
+            spec = spec.and((root, query, cb) -> cb.equal(root.get("assignee").get("id"), assigneeId));
+        }
+        Page<Task> page = taskRepository.findAll(spec, pageable);
+        return new PageResponse<>(
+                page.map(this::mapToSummary).getContent(),
+                page.getTotalElements(),
+                page.getTotalPages(),
+                page.getNumber(),
+                page.getSize());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public TaskResponse getTask(Long id) {
+        Task task = loadTaskForCurrentUser(id);
+        return mapToResponse(task);
+    }
+
+    @Override
+    public TaskResponse createTask(Long projectId, TaskRequest request) {
+        Project project = loadProjectForCurrentUser(projectId);
+        Task task = new Task();
+        task.setProject(project);
+        applyTaskRequest(task, request);
+        Task saved = taskRepository.save(task);
+        log.info("Task created: {} in project {}", saved.getId(), projectId);
+        return mapToResponse(saved);
+    }
+
+    @Override
+    public TaskResponse updateTask(Long taskId, TaskRequest request) {
+        Task task = loadTaskForCurrentUser(taskId);
+        applyTaskRequest(task, request);
+        Task updated = taskRepository.save(task);
+        log.info("Task updated: {}", updated.getId());
+        return mapToResponse(updated);
+    }
+
+    @Override
+    public void deleteTask(Long id) {
+        Task task = loadTaskForCurrentUser(id);
+        taskRepository.delete(task);
+        log.info("Task deleted: {}", task.getId());
+    }
+
+    private void applyTaskRequest(Task task, TaskRequest request) {
+        task.setTitle(request.getTitle());
+        task.setDescription(request.getDescription());
+        task.setStatus(request.getStatus());
+        task.setPriority(request.getPriority());
+        if (request.getAssigneeId() != null) {
+            User assignee = userRepository.findById(request.getAssigneeId())
+                    .orElseThrow(() -> new BadRequestException("Assignee not found"));
+            task.setAssignee(assignee);
+        } else {
+            task.setAssignee(null);
+        }
+        task.setDueDate(request.getDueDate());
+    }
+
+    private Task loadTaskForCurrentUser(Long id) {
+        Task task = taskRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Task not found"));
+        ensureAccessToProject(task.getProject());
+        return task;
+    }
+
+    private Project loadProjectForCurrentUser(Long projectId) {
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(() -> new ResourceNotFoundException("Project not found"));
+        ensureAccessToProject(project);
+        return project;
+    }
+
+    private void ensureAccessToProject(Project project) {
+        User current = SecurityUtils.getCurrentUser();
+        if (current.getRole() == Role.ADMIN) {
+            return;
+        }
+        boolean owner = project.getOwner().getId().equals(current.getId());
+        boolean assignee = project.getTasks().stream()
+                .map(Task::getAssignee)
+                .filter(a -> a != null)
+                .anyMatch(a -> a.getId().equals(current.getId()));
+        if (!owner && !assignee) {
+            throw new ResourceNotFoundException("Project not found");
+        }
+    }
+
+    private TaskSummary mapToSummary(Task task) {
+        TaskSummary summary = new TaskSummary();
+        summary.setId(task.getId());
+        summary.setTitle(task.getTitle());
+        summary.setStatus(task.getStatus());
+        summary.setPriority(task.getPriority());
+        summary.setDueDate(task.getDueDate());
+        summary.setAssigneeName(task.getAssignee() != null ? task.getAssignee().getFullName() : null);
+        return summary;
+    }
+
+    private TaskResponse mapToResponse(Task task) {
+        TaskResponse response = new TaskResponse();
+        response.setId(task.getId());
+        response.setProjectId(task.getProject().getId());
+        response.setTitle(task.getTitle());
+        response.setDescription(task.getDescription());
+        response.setStatus(task.getStatus());
+        response.setPriority(task.getPriority());
+        if (task.getAssignee() != null) {
+            response.setAssigneeId(task.getAssignee().getId());
+            response.setAssigneeName(task.getAssignee().getFullName());
+        }
+        response.setDueDate(task.getDueDate());
+        response.setCreatedAt(task.getCreatedAt());
+        List<Comment> comments = commentRepository.findByTaskOrderByCreatedAtAsc(task);
+        List<CommentResponse> commentDtos = comments.stream().map(comment -> {
+            CommentResponse dto = new CommentResponse();
+            dto.setId(comment.getId());
+            dto.setTaskId(task.getId());
+            dto.setAuthorId(comment.getAuthor().getId());
+            dto.setAuthorName(comment.getAuthor().getFullName());
+            dto.setText(comment.getText());
+            dto.setCreatedAt(comment.getCreatedAt());
+            return dto;
+        }).collect(Collectors.toList());
+        response.setComments(commentDtos);
+        response.setAttachments(task.getAttachments().stream().map(attachment -> {
+            TaskResponse.AttachmentResponse dto = new TaskResponse.AttachmentResponse();
+            dto.setId(attachment.getId());
+            dto.setFileName(attachment.getFileName());
+            dto.setContentType(attachment.getContentType());
+            dto.setUploadedAt(attachment.getUploadedAt());
+            dto.setUrl("/api/attachments/" + attachment.getId());
+            return dto;
+        }).collect(Collectors.toList()));
+        return response;
+    }
+}

--- a/backend/src/main/java/com/example/minitasker/service/impl/UserServiceImpl.java
+++ b/backend/src/main/java/com/example/minitasker/service/impl/UserServiceImpl.java
@@ -1,0 +1,71 @@
+package com.example.minitasker.service.impl;
+
+import com.example.minitasker.dto.PageResponse;
+import com.example.minitasker.dto.auth.UpdateUserRequest;
+import com.example.minitasker.dto.auth.UserResponse;
+import com.example.minitasker.exception.ResourceNotFoundException;
+import com.example.minitasker.model.User;
+import com.example.minitasker.repository.UserRepository;
+import com.example.minitasker.service.UserService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class UserServiceImpl implements UserService {
+
+    private final UserRepository userRepository;
+
+    public UserServiceImpl(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public PageResponse<UserResponse> listUsers(Pageable pageable) {
+        Page<User> page = userRepository.findAll(pageable);
+        return new PageResponse<>(
+                page.map(this::mapToDto).getContent(),
+                page.getTotalElements(),
+                page.getTotalPages(),
+                page.getNumber(),
+                page.getSize());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public UserResponse getUser(Long id) {
+        User user = userRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("User not found"));
+        return mapToDto(user);
+    }
+
+    @Override
+    public UserResponse updateUser(Long id, UpdateUserRequest request) {
+        User user = userRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("User not found"));
+        user.setFullName(request.getFullName());
+        user.setRole(request.getRole());
+        return mapToDto(userRepository.save(user));
+    }
+
+    @Override
+    public void deleteUser(Long id) {
+        if (!userRepository.existsById(id)) {
+            throw new ResourceNotFoundException("User not found");
+        }
+        userRepository.deleteById(id);
+    }
+
+    private UserResponse mapToDto(User user) {
+        UserResponse response = new UserResponse();
+        response.setId(user.getId());
+        response.setEmail(user.getEmail());
+        response.setFullName(user.getFullName());
+        response.setRole(user.getRole().name());
+        response.setCreatedAt(user.getCreatedAt());
+        return response;
+    }
+}

--- a/backend/src/main/java/com/example/minitasker/util/SecurityUtils.java
+++ b/backend/src/main/java/com/example/minitasker/util/SecurityUtils.java
@@ -1,0 +1,20 @@
+package com.example.minitasker.util;
+
+import com.example.minitasker.model.User;
+import com.example.minitasker.security.CustomUserDetails;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+public final class SecurityUtils {
+
+    private SecurityUtils() {
+    }
+
+    public static User getCurrentUser() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !(authentication.getPrincipal() instanceof CustomUserDetails userDetails)) {
+            throw new IllegalStateException("No authenticated user");
+        }
+        return userDetails.getUser();
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,0 +1,32 @@
+spring:
+  datasource:
+    url: jdbc:postgresql://localhost:5432/minitasker
+    username: minitasker
+    password: minitasker
+    driver-class-name: org.postgresql.Driver
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        format_sql: true
+    open-in-view: false
+  servlet:
+    multipart:
+      max-file-size: 20MB
+      max-request-size: 20MB
+
+logging:
+  level:
+    root: INFO
+    com.example.minitasker: DEBUG
+
+minitasker:
+  security:
+    jwt-secret: change-me-please-change-me-please-change-me-please
+    jwt-expiration-minutes: 60
+  storage:
+    upload-dir: ./uploads
+
+server:
+  port: 8080


### PR DESCRIPTION
## Summary
- create Spring Boot backend for MiniTasker with JWT security, CRUD endpoints, file attachments, reports, and statistics
- add Android MVVM client using Jetpack Compose, Retrofit, and DataStore covering auth, project/task management, comments, attachments, and stats screens
- document backend and Android structures plus setup instructions in README

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691703cfbfb08333ab88ace670f27742)