### PR TITLE
Fix task updates and emulator networking

### DIFF
--- a/android/app/src/debug/AndroidManifest.xml
+++ b/android/app/src/debug/AndroidManifest.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application
+        android:usesCleartextTraffic="true"
+        android:networkSecurityConfig="@xml/network_security_config" />
+</manifest>

--- a/android/app/src/debug/res/xml/network_security_config.xml
+++ b/android/app/src/debug/res/xml/network_security_config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="false">10.0.2.2</domain>
+    </domain-config>
+</network-security-config>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -11,9 +11,7 @@
         android:icon="@android:drawable/sym_def_app_icon"
         android:label="MiniTasker"
         android:supportsRtl="true"
-        android:theme="@android:style/Theme.Material.NoActionBar"
-        android:usesCleartextTraffic="true"
-        android:networkSecurityConfig="@xml/network_security_config">
+        android:theme="@android:style/Theme.Material.NoActionBar">
 
         <activity
             android:name="com.example.minitasker.MainActivity"

--- a/android/app/src/main/java/com/example/minitasker/MainActivity.kt
+++ b/android/app/src/main/java/com/example/minitasker/MainActivity.kt
@@ -6,6 +6,7 @@ import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -50,6 +51,11 @@ fun MiniTaskerNavHost(app: MiniTaskerApplication) {
     val tasksViewModel: TasksViewModel = viewModel(factory = SimpleFactory { TasksViewModel(app.taskRepository) })
     val taskDetailViewModel: TaskDetailViewModel = viewModel(factory = SimpleFactory { TaskDetailViewModel(app.taskRepository) })
     val statsViewModel: StatsViewModel = viewModel(factory = SimpleFactory { StatsViewModel(app.statsRepository) })
+
+    LaunchedEffect(Unit) {
+        tasksViewModel.onTasksChanged = { projectId -> statsViewModel.load(projectId) }
+        taskDetailViewModel.onTaskChanged = { projectId -> statsViewModel.load(projectId) }
+    }
 
     NavHost(navController = navController, startDestination = Screen.Auth.route) {
         composable(Screen.Auth.route) {

--- a/android/app/src/main/java/com/example/minitasker/data/model/TaskModels.kt
+++ b/android/app/src/main/java/com/example/minitasker/data/model/TaskModels.kt
@@ -1,12 +1,14 @@
 package com.example.minitasker.data.model
 
-import com.squareup.moshi.Json
+enum class TaskStatus { TODO, IN_PROGRESS, DONE }
+
+enum class TaskPriority { LOW, MEDIUM, HIGH }
 
 data class TaskRequest(
     val title: String,
     val description: String?,
-    val status: String,
-    val priority: String,
+    val status: TaskStatus,
+    val priority: TaskPriority,
     val assigneeId: Long?,
     val dueDate: String?
 )
@@ -14,8 +16,8 @@ data class TaskRequest(
 data class TaskSummaryDto(
     val id: Long,
     val title: String,
-    val status: String,
-    val priority: String,
+    val status: TaskStatus,
+    val priority: TaskPriority,
     val dueDate: String?,
     val assigneeName: String?
 )
@@ -25,8 +27,8 @@ data class TaskResponseDto(
     val projectId: Long,
     val title: String,
     val description: String?,
-    val status: String,
-    val priority: String,
+    val status: TaskStatus,
+    val priority: TaskPriority,
     val assigneeId: Long?,
     val assigneeName: String?,
     val dueDate: String?,

--- a/android/app/src/main/java/com/example/minitasker/data/repository/ServiceLocator.kt
+++ b/android/app/src/main/java/com/example/minitasker/data/repository/ServiceLocator.kt
@@ -13,7 +13,7 @@ import retrofit2.converter.moshi.MoshiConverterFactory
 
 object ServiceLocator {
 
-    private const val BASE_URL = "http://127.0.0.1:8080"
+    private const val BASE_URL = "http://10.0.2.2:8080"
 
     fun provideAuthPreferences(context: Context): AuthPreferences = AuthPreferences(context)
 

--- a/android/app/src/main/java/com/example/minitasker/ui/screen/taskdetail/TaskDetailScreen.kt
+++ b/android/app/src/main/java/com/example/minitasker/ui/screen/taskdetail/TaskDetailScreen.kt
@@ -31,6 +31,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.example.minitasker.data.model.TaskRequest
+import com.example.minitasker.data.model.TaskPriority
+import com.example.minitasker.data.model.TaskStatus
 
 @Composable
 fun TaskDetailScreen(taskId: Long, viewModel: TaskDetailViewModel) {
@@ -52,32 +54,32 @@ fun TaskDetailScreen(taskId: Long, viewModel: TaskDetailViewModel) {
             Spacer(modifier = Modifier.height(8.dp))
             Text(text = task.description ?: "Нет описания")
             Spacer(modifier = Modifier.height(8.dp))
-            Text(text = "Статус: ${task.status}")
-            Text(text = "Приоритет: ${task.priority}")
+            Text(text = "Статус: ${task.status.name}")
+            Text(text = "Приоритет: ${task.priority.name}")
             task.assigneeName?.let { Text(text = "Исполнитель: $it") }
             task.dueDate?.let { Text(text = "Срок: $it") }
             Spacer(modifier = Modifier.height(12.dp))
             Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                StatusChip(label = "TODO", selected = task.status == "TODO") {
-                    viewModel.updateTask(taskId, task.toRequest(status = "TODO"))
+                StatusChip(label = "TODO", selected = task.status == TaskStatus.TODO) {
+                    viewModel.updateTask(taskId, task.toRequest(status = TaskStatus.TODO))
                 }
-                StatusChip(label = "IN_PROGRESS", selected = task.status == "IN_PROGRESS") {
-                    viewModel.updateTask(taskId, task.toRequest(status = "IN_PROGRESS"))
+                StatusChip(label = "IN_PROGRESS", selected = task.status == TaskStatus.IN_PROGRESS) {
+                    viewModel.updateTask(taskId, task.toRequest(status = TaskStatus.IN_PROGRESS))
                 }
-                StatusChip(label = "DONE", selected = task.status == "DONE") {
-                    viewModel.updateTask(taskId, task.toRequest(status = "DONE"))
+                StatusChip(label = "DONE", selected = task.status == TaskStatus.DONE) {
+                    viewModel.updateTask(taskId, task.toRequest(status = TaskStatus.DONE))
                 }
             }
             Spacer(modifier = Modifier.height(8.dp))
             Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                StatusChip(label = "LOW", selected = task.priority == "LOW") {
-                    viewModel.updateTask(taskId, task.toRequest(priority = "LOW"))
+                StatusChip(label = "LOW", selected = task.priority == TaskPriority.LOW) {
+                    viewModel.updateTask(taskId, task.toRequest(priority = TaskPriority.LOW))
                 }
-                StatusChip(label = "MEDIUM", selected = task.priority == "MEDIUM") {
-                    viewModel.updateTask(taskId, task.toRequest(priority = "MEDIUM"))
+                StatusChip(label = "MEDIUM", selected = task.priority == TaskPriority.MEDIUM) {
+                    viewModel.updateTask(taskId, task.toRequest(priority = TaskPriority.MEDIUM))
                 }
-                StatusChip(label = "HIGH", selected = task.priority == "HIGH") {
-                    viewModel.updateTask(taskId, task.toRequest(priority = "HIGH"))
+                StatusChip(label = "HIGH", selected = task.priority == TaskPriority.HIGH) {
+                    viewModel.updateTask(taskId, task.toRequest(priority = TaskPriority.HIGH))
                 }
             }
             Spacer(modifier = Modifier.height(16.dp))
@@ -131,8 +133,8 @@ fun TaskDetailScreen(taskId: Long, viewModel: TaskDetailViewModel) {
 }
 
 private fun com.example.minitasker.data.model.TaskResponseDto.toRequest(
-    status: String = this.status,
-    priority: String = this.priority
+    status: TaskStatus = this.status,
+    priority: TaskPriority = this.priority
 ): TaskRequest {
     return TaskRequest(
         title = this.title,

--- a/android/app/src/main/java/com/example/minitasker/ui/screen/taskdetail/TaskDetailViewModel.kt
+++ b/android/app/src/main/java/com/example/minitasker/ui/screen/taskdetail/TaskDetailViewModel.kt
@@ -25,6 +25,8 @@ class TaskDetailViewModel(private val repository: TaskRepository) : ViewModel() 
     private val _state = MutableStateFlow(TaskDetailUiState())
     val state: StateFlow<TaskDetailUiState> = _state.asStateFlow()
 
+    var onTaskChanged: ((Long) -> Unit)? = null
+
     fun loadTask(taskId: Long) {
         viewModelScope.launch {
             _state.value = _state.value.copy(loading = true, error = null)
@@ -39,7 +41,10 @@ class TaskDetailViewModel(private val repository: TaskRepository) : ViewModel() 
     fun updateTask(taskId: Long, request: TaskRequest) {
         viewModelScope.launch {
             when (val result = safeCall { repository.updateTask(taskId, request) }) {
-                is NetworkResult.Success -> _state.value = _state.value.copy(task = result.data, error = null)
+                is NetworkResult.Success -> {
+                    _state.value = _state.value.copy(task = result.data, error = null)
+                    onTaskChanged?.invoke(result.data.projectId)
+                }
                 is NetworkResult.Error -> _state.value = _state.value.copy(error = result.message)
                 NetworkResult.Loading -> Unit
             }

--- a/android/app/src/main/java/com/example/minitasker/ui/screen/tasks/TasksScreen.kt
+++ b/android/app/src/main/java/com/example/minitasker/ui/screen/tasks/TasksScreen.kt
@@ -124,7 +124,7 @@ private fun TaskItem(task: TaskSummaryDto, onClick: () -> Unit) {
         Column(modifier = Modifier.padding(16.dp)) {
             Text(text = task.title, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
             Spacer(modifier = Modifier.height(4.dp))
-            Text(text = "Статус: ${task.status} | Приоритет: ${task.priority}")
+            Text(text = "Статус: ${task.status.name} | Приоритет: ${task.priority.name}")
             task.assigneeName?.let { Text(text = "Исполнитель: $it") }
             task.dueDate?.let { Text(text = "Срок: $it") }
         }

--- a/android/app/src/main/java/com/example/minitasker/ui/screen/tasks/TasksViewModel.kt
+++ b/android/app/src/main/java/com/example/minitasker/ui/screen/tasks/TasksViewModel.kt
@@ -4,6 +4,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.minitasker.data.model.TaskRequest
 import com.example.minitasker.data.model.TaskSummaryDto
+import com.example.minitasker.data.model.TaskPriority
+import com.example.minitasker.data.model.TaskStatus
 import com.example.minitasker.data.repository.NetworkResult
 import com.example.minitasker.data.repository.TaskRepository
 import com.example.minitasker.data.repository.safeCall
@@ -20,6 +22,7 @@ data class TasksUiState(
     val items: List<TaskSummaryDto> = emptyList(),
     val loading: Boolean = false,
     val error: String? = null,
+    val projectId: Long? = null,
     val status: TaskStatusFilter = TaskStatusFilter.ALL,
     val priority: TaskPriorityFilter = TaskPriorityFilter.ALL
 )
@@ -28,6 +31,8 @@ class TasksViewModel(private val repository: TaskRepository) : ViewModel() {
 
     private val _state = MutableStateFlow(TasksUiState())
     val state: StateFlow<TasksUiState> = _state.asStateFlow()
+
+    var onTasksChanged: ((Long) -> Unit)? = null
 
     fun loadTasks(projectId: Long) {
         viewModelScope.launch {
@@ -39,10 +44,14 @@ class TasksViewModel(private val repository: TaskRepository) : ViewModel() {
             }) {
                 is NetworkResult.Success -> _state.value = _state.value.copy(
                     loading = false,
-                    items = result.data.content
+                    items = result.data.content,
+                    projectId = projectId
                 )
                 is NetworkResult.Error -> _state.value = _state.value.copy(loading = false, error = result.message)
                 NetworkResult.Loading -> _state.value = _state.value.copy(loading = true)
+            }
+            if (_state.value.error == null) {
+                onTasksChanged?.invoke(projectId)
             }
         }
     }
@@ -59,9 +68,12 @@ class TasksViewModel(private val repository: TaskRepository) : ViewModel() {
 
     fun createTask(projectId: Long, title: String) {
         viewModelScope.launch {
-            val request = TaskRequest(title, description = null, status = "TODO", priority = "MEDIUM", assigneeId = null, dueDate = null)
+            val request = TaskRequest(title, description = null, status = TaskStatus.TODO, priority = TaskPriority.MEDIUM, assigneeId = null, dueDate = null)
             when (safeCall { repository.createTask(projectId, request) }) {
-                is NetworkResult.Success -> loadTasks(projectId)
+                is NetworkResult.Success -> {
+                    _state.value = _state.value.copy(status = TaskStatusFilter.ALL)
+                    loadTasks(projectId)
+                }
                 is NetworkResult.Error -> _state.value = _state.value.copy(error = "Не удалось создать задачу")
                 NetworkResult.Loading -> Unit
             }


### PR DESCRIPTION
## Summary
- point Retrofit to the Android emulator host and add a debug network security config for HTTP access to 10.0.2.2
- enforce task status/priority enums, reset filters after creating tasks, and surface new tasks immediately
- trigger statistics reloads whenever tasks are loaded or updated from the detail screen

## Testing
- Not run (gradlew not executable in the container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919b48d33448333bac1ce2cc11d9783)