### PR TITLE
Fix controller parameter names and compiler settings

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -1,0 +1,12 @@
+plugins {
+    java
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
+tasks.withType<JavaCompile>().configureEach {
+    options.compilerArgs.add("-parameters")
+}

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -104,6 +104,9 @@
                 <configuration>
                     <source>${java.version}</source>
                     <target>${java.version}</target>
+                    <compilerArgs>
+                        <arg>-parameters</arg>
+                    </compilerArgs>
                 </configuration>
             </plugin>
         </plugins>

--- a/backend/src/main/java/com/example/minitasker/controller/AttachmentController.java
+++ b/backend/src/main/java/com/example/minitasker/controller/AttachmentController.java
@@ -27,19 +27,19 @@ public class AttachmentController {
     }
 
     @GetMapping("/tasks/{taskId}/attachments")
-    public ResponseEntity<List<AttachmentResponse>> listAttachments(@PathVariable Long taskId) {
+    public ResponseEntity<List<AttachmentResponse>> listAttachments(@PathVariable("taskId") Long taskId) {
         return ResponseEntity.ok(attachmentService.listAttachments(taskId));
     }
 
     @PostMapping(value = "/tasks/{taskId}/attachments", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<AttachmentResponse> uploadAttachment(@PathVariable Long taskId,
+    public ResponseEntity<AttachmentResponse> uploadAttachment(@PathVariable("taskId") Long taskId,
                                                                @RequestParam("file") MultipartFile file)
             throws IOException {
         return ResponseEntity.ok(attachmentService.uploadAttachment(taskId, file));
     }
 
     @GetMapping("/attachments/{attachmentId}")
-    public ResponseEntity<Resource> downloadAttachment(@PathVariable Long attachmentId) {
+    public ResponseEntity<Resource> downloadAttachment(@PathVariable("attachmentId") Long attachmentId) {
         Resource resource = attachmentService.downloadAttachment(attachmentId);
         return ResponseEntity.ok()
                 .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=" + resource.getFilename())

--- a/backend/src/main/java/com/example/minitasker/controller/CommentController.java
+++ b/backend/src/main/java/com/example/minitasker/controller/CommentController.java
@@ -24,12 +24,12 @@ public class CommentController {
     }
 
     @GetMapping
-    public ResponseEntity<List<CommentResponse>> listComments(@PathVariable Long taskId) {
+    public ResponseEntity<List<CommentResponse>> listComments(@PathVariable("taskId") Long taskId) {
         return ResponseEntity.ok(commentService.getComments(taskId));
     }
 
     @PostMapping
-    public ResponseEntity<CommentResponse> createComment(@PathVariable Long taskId,
+    public ResponseEntity<CommentResponse> createComment(@PathVariable("taskId") Long taskId,
                                                          @Valid @RequestBody CommentRequest request) {
         return ResponseEntity.ok(commentService.addComment(taskId, request));
     }

--- a/backend/src/main/java/com/example/minitasker/controller/ProjectController.java
+++ b/backend/src/main/java/com/example/minitasker/controller/ProjectController.java
@@ -29,15 +29,15 @@ public class ProjectController {
     }
 
     @GetMapping
-    public ResponseEntity<PageResponse<ProjectResponse>> listProjects(@RequestParam(required = false) String name,
-                                                                      @RequestParam(defaultValue = "0") int page,
-                                                                      @RequestParam(defaultValue = "20") int size) {
+    public ResponseEntity<PageResponse<ProjectResponse>> listProjects(@RequestParam(value = "name", required = false) String name,
+                                                                      @RequestParam(value = "page", defaultValue = "0") int page,
+                                                                      @RequestParam(value = "size", defaultValue = "20") int size) {
         Pageable pageable = PageRequest.of(page, size);
         return ResponseEntity.ok(projectService.getProjects(name, pageable));
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<ProjectResponse> getProject(@PathVariable Long id) {
+    public ResponseEntity<ProjectResponse> getProject(@PathVariable("id") Long id) {
         return ResponseEntity.ok(projectService.getProject(id));
     }
 
@@ -47,13 +47,13 @@ public class ProjectController {
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<ProjectResponse> updateProject(@PathVariable Long id,
+    public ResponseEntity<ProjectResponse> updateProject(@PathVariable("id") Long id,
                                                          @Valid @RequestBody ProjectRequest request) {
         return ResponseEntity.ok(projectService.updateProject(id, request));
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deleteProject(@PathVariable Long id) {
+    public ResponseEntity<Void> deleteProject(@PathVariable("id") Long id) {
         projectService.deleteProject(id);
         return ResponseEntity.noContent().build();
     }

--- a/backend/src/main/java/com/example/minitasker/controller/ReportController.java
+++ b/backend/src/main/java/com/example/minitasker/controller/ReportController.java
@@ -21,7 +21,7 @@ public class ReportController {
     }
 
     @GetMapping(value = "/tasks/csv", produces = "text/csv")
-    public ResponseEntity<Resource> downloadCsv(@RequestParam Long projectId) {
+    public ResponseEntity<Resource> downloadCsv(@RequestParam("projectId") Long projectId) {
         Resource resource = reportService.generateTasksCsv(projectId);
         return ResponseEntity.ok()
                 .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=" + resource.getFilename())

--- a/backend/src/main/java/com/example/minitasker/controller/StatsController.java
+++ b/backend/src/main/java/com/example/minitasker/controller/StatsController.java
@@ -20,12 +20,12 @@ public class StatsController {
     }
 
     @GetMapping("/tasks-by-status")
-    public ResponseEntity<List<KeyValueStat>> tasksByStatus(@RequestParam Long projectId) {
+    public ResponseEntity<List<KeyValueStat>> tasksByStatus(@RequestParam("projectId") Long projectId) {
         return ResponseEntity.ok(statsService.tasksByStatus(projectId));
     }
 
     @GetMapping("/tasks-by-priority")
-    public ResponseEntity<List<KeyValueStat>> tasksByPriority(@RequestParam Long projectId) {
+    public ResponseEntity<List<KeyValueStat>> tasksByPriority(@RequestParam("projectId") Long projectId) {
         return ResponseEntity.ok(statsService.tasksByPriority(projectId));
     }
 }

--- a/backend/src/main/java/com/example/minitasker/controller/TaskController.java
+++ b/backend/src/main/java/com/example/minitasker/controller/TaskController.java
@@ -30,35 +30,35 @@ public class TaskController {
     }
 
     @GetMapping("/projects/{projectId}/tasks")
-    public ResponseEntity<PageResponse<TaskSummary>> listTasks(@PathVariable Long projectId,
-                                                               @RequestParam(required = false) String status,
-                                                               @RequestParam(required = false) String priority,
-                                                               @RequestParam(required = false) Long assigneeId,
-                                                               @RequestParam(defaultValue = "0") int page,
-                                                               @RequestParam(defaultValue = "20") int size) {
+    public ResponseEntity<PageResponse<TaskSummary>> listTasks(@PathVariable("projectId") Long projectId,
+                                                               @RequestParam(value = "status", required = false) String status,
+                                                               @RequestParam(value = "priority", required = false) String priority,
+                                                               @RequestParam(value = "assigneeId", required = false) Long assigneeId,
+                                                               @RequestParam(value = "page", defaultValue = "0") int page,
+                                                               @RequestParam(value = "size", defaultValue = "20") int size) {
         Pageable pageable = PageRequest.of(page, size);
         return ResponseEntity.ok(taskService.getTasks(projectId, status, priority, assigneeId, pageable));
     }
 
     @PostMapping("/projects/{projectId}/tasks")
-    public ResponseEntity<TaskResponse> createTask(@PathVariable Long projectId,
+    public ResponseEntity<TaskResponse> createTask(@PathVariable("projectId") Long projectId,
                                                    @Valid @RequestBody TaskRequest request) {
         return ResponseEntity.ok(taskService.createTask(projectId, request));
     }
 
     @GetMapping("/tasks/{taskId}")
-    public ResponseEntity<TaskResponse> getTask(@PathVariable Long taskId) {
+    public ResponseEntity<TaskResponse> getTask(@PathVariable("taskId") Long taskId) {
         return ResponseEntity.ok(taskService.getTask(taskId));
     }
 
     @PutMapping("/tasks/{taskId}")
-    public ResponseEntity<TaskResponse> updateTask(@PathVariable Long taskId,
+    public ResponseEntity<TaskResponse> updateTask(@PathVariable("taskId") Long taskId,
                                                    @Valid @RequestBody TaskRequest request) {
         return ResponseEntity.ok(taskService.updateTask(taskId, request));
     }
 
     @DeleteMapping("/tasks/{taskId}")
-    public ResponseEntity<Void> deleteTask(@PathVariable Long taskId) {
+    public ResponseEntity<Void> deleteTask(@PathVariable("taskId") Long taskId) {
         taskService.deleteTask(taskId);
         return ResponseEntity.noContent().build();
     }

--- a/backend/src/main/java/com/example/minitasker/controller/UserController.java
+++ b/backend/src/main/java/com/example/minitasker/controller/UserController.java
@@ -28,25 +28,25 @@ public class UserController {
     }
 
     @GetMapping
-    public ResponseEntity<PageResponse<UserResponse>> listUsers(@RequestParam(defaultValue = "0") int page,
-                                                                @RequestParam(defaultValue = "20") int size) {
+    public ResponseEntity<PageResponse<UserResponse>> listUsers(@RequestParam(value = "page", defaultValue = "0") int page,
+                                                                @RequestParam(value = "size", defaultValue = "20") int size) {
         Pageable pageable = PageRequest.of(page, size);
         return ResponseEntity.ok(userService.listUsers(pageable));
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<UserResponse> getUser(@PathVariable Long id) {
+    public ResponseEntity<UserResponse> getUser(@PathVariable("id") Long id) {
         return ResponseEntity.ok(userService.getUser(id));
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<UserResponse> updateUser(@PathVariable Long id,
+    public ResponseEntity<UserResponse> updateUser(@PathVariable("id") Long id,
                                                    @Valid @RequestBody UpdateUserRequest request) {
         return ResponseEntity.ok(userService.updateUser(id, request));
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deleteUser(@PathVariable Long id) {
+    public ResponseEntity<Void> deleteUser(@PathVariable("id") Long id) {
         userService.deleteUser(id);
         return ResponseEntity.noContent().build();
     }


### PR DESCRIPTION
## Summary
- add explicit names to request parameters and path variables to avoid IllegalArgument exceptions
- enable Java compilation with `-parameters` flag for both Maven and Gradle builds

## Testing
- mvn -q -DskipTests compile *(fails: Maven Central 502 while resolving plugins)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919c0966a488333949a8dce9e636152)