### PR TITLE
Add Docker setup for backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,20 @@ MiniTasker — учебный full-stack проект, состоящий из b
    (или `mvn spring-boot:run`, если Maven установлен глобально).
 3. API доступно на `http://localhost:8080`.
 
+## Запуск backend в Docker
+1. Установите [Docker](https://docs.docker.com/get-docker/) и [Docker Compose](https://docs.docker.com/compose/install/).
+2. Соберите образ вручную (контекст — каталог `backend`):
+   ```bash
+   docker build -t minitasker-backend ./backend
+   ```
+3. Поднимите backend вместе с PostgreSQL при помощи docker compose (команда автоматически стартует и сервис `postgres` благодаря `depends_on`):
+   ```bash
+   docker compose up backend
+   ```
+   Образы будут собраны, после чего backend станет доступен, а данные PostgreSQL сохранятся в томе `postgres-data`.
+4. API доступно на `http://localhost:8080` (порт проброшен из контейнера `backend`).
+5. Для Android-эмулятора ничего менять не нужно — он по-прежнему обращается к `http://10.0.2.2:8080`, поэтому при пробросе `8080:8080` всё работает как и при локальном запуске.
+
 ## Сборка и запуск Android-клиента
 1. Откройте каталог `android/` в Android Studio (Giraffe+).
 2. Убедитесь, что устройство/эмулятор могут обратиться к backend (`10.0.2.2:8080` для эмулятора, при необходимости измените `ServiceLocator.BASE_URL`).

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,20 @@
+# Maven build output
+/target
+
+# Gradle build output (in case developers use it locally)
+/build
+
+# IDE/editor settings
+/.idea
+/.vscode
+*.iml
+
+# VCS
+/.git
+.gitignore
+
+# Logs and temp files
+*.log
+*.tmp
+.DS_Store
+Thumbs.db

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,24 @@
+# syntax=docker/dockerfile:1
+
+# ---------- Build stage ----------
+FROM maven:3.9.6-eclipse-temurin-17 AS builder
+WORKDIR /app
+
+# Copy only pom first to leverage Docker layer caching
+COPY pom.xml ./
+RUN mvn -B dependency:go-offline
+
+# Copy sources and build the application
+COPY src ./src
+RUN mvn -B -DskipTests clean package
+
+# ---------- Runtime stage ----------
+FROM eclipse-temurin:17-jre
+WORKDIR /app
+
+# Copy the Spring Boot fat jar from the build stage
+COPY --from=builder /app/target/minitasker-backend-0.0.1-SNAPSHOT.jar /app/app.jar
+
+EXPOSE 8080
+
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,37 @@
+services:
+  postgres:
+    image: postgres:15
+    container_name: minitasker-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: minitasker
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d minitasker"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  backend:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    container_name: minitasker-backend
+    restart: unless-stopped
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/minitasker
+      SPRING_DATASOURCE_USERNAME: postgres
+      SPRING_DATASOURCE_PASSWORD: postgres
+    ports:
+      - "8080:8080"
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+volumes:
+  postgres-data:


### PR DESCRIPTION
## Summary
- add a multi-stage Dockerfile and dockerignore for the Spring Boot backend
- introduce a docker compose stack with PostgreSQL and wire the backend to use datasource env vars
- document how to run the backend via Docker

## Testing
- mvn -DskipTests package

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ae1f1bc2c8333a32ed4a510058250)