### PR TITLE
Fix Spring Boot jar packaging for backend

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -6,6 +6,7 @@
     <groupId>com.example</groupId>
     <artifactId>minitasker-backend</artifactId>
     <version>0.0.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
     <name>MiniTasker Backend</name>
     <description>Spring Boot backend for MiniTasker application</description>
 
@@ -96,6 +97,14 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring.boot.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## Summary
- ensure the backend pom produces an executable Spring Boot jar by specifying the packaging and binding the `spring-boot-maven-plugin` repackage goal
- this allows the existing Dockerfile entrypoint to run the generated fat jar inside the container

## Testing
- `mvn -B -DskipTests clean package`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691aeb34735883338598be3bb7c35665)