### PR TITLE
Implement priority selection and task take flow

### DIFF
--- a/android/app/src/main/java/com/example/minitasker/data/api/ApiService.kt
+++ b/android/app/src/main/java/com/example/minitasker/data/api/ApiService.kt
@@ -77,6 +77,12 @@ interface ApiService {
     @DELETE("/api/tasks/{taskId}")
     suspend fun deleteTask(@Path("taskId") taskId: Long)
 
+    @POST("/api/projects/{projectId}/tasks/{taskId}/take")
+    suspend fun takeTask(
+        @Path("projectId") projectId: Long,
+        @Path("taskId") taskId: Long
+    ): TaskResponseDto
+
     // Comments
     @GET("/api/tasks/{taskId}/comments")
     suspend fun getComments(@Path("taskId") taskId: Long): List<CommentDto>

--- a/android/app/src/main/java/com/example/minitasker/data/repository/TaskRepository.kt
+++ b/android/app/src/main/java/com/example/minitasker/data/repository/TaskRepository.kt
@@ -46,6 +46,10 @@ class TaskRepository(private val context: Context, private val apiService: ApiSe
         apiService.deleteTask(taskId)
     }
 
+    suspend fun takeTask(projectId: Long, taskId: Long): TaskResponseDto {
+        return apiService.takeTask(projectId, taskId)
+    }
+
     suspend fun getComments(taskId: Long): List<CommentDto> {
         return apiService.getComments(taskId)
     }

--- a/android/app/src/main/java/com/example/minitasker/ui/screen/stats/StatsScreen.kt
+++ b/android/app/src/main/java/com/example/minitasker/ui/screen/stats/StatsScreen.kt
@@ -1,8 +1,10 @@
 package com.example.minitasker.ui.screen.stats
 
-import androidx.compose.ui.unit.dp
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -11,11 +13,15 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import com.github.mikephil.charting.charts.PieChart
 import com.github.mikephil.charting.data.PieData
 import com.github.mikephil.charting.data.PieDataSet
 import com.github.mikephil.charting.data.PieEntry
+import com.example.minitasker.data.model.TaskPriority
+import com.example.minitasker.data.model.TaskStatus
+import com.example.minitasker.data.model.StatsDto
 
 @Composable
 fun StatsScreen(projectId: Long, projectName: String, viewModel: StatsViewModel) {
@@ -27,7 +33,10 @@ fun StatsScreen(projectId: Long, projectName: String, viewModel: StatsViewModel)
 
     Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
         Text(text = "Статистика по проекту $projectName", style = MaterialTheme.typography.headlineSmall)
-        AndroidView(factory = { context ->
+        AndroidView(modifier = Modifier
+            .padding(vertical = 12.dp)
+            .fillMaxWidth()
+            .height(220.dp), factory = { context ->
             PieChart(context).apply {
                 description.isEnabled = false
             }
@@ -37,7 +46,12 @@ fun StatsScreen(projectId: Long, projectName: String, viewModel: StatsViewModel)
             chart.data = PieData(dataSet)
             chart.invalidate()
         })
-        AndroidView(factory = { context ->
+        StatsListSection(title = "По статусам", stats = state.statusStats, labelProvider = { formatStatusLabel(it) })
+        Spacer(modifier = Modifier.height(16.dp))
+        AndroidView(modifier = Modifier
+            .padding(vertical = 12.dp)
+            .fillMaxWidth()
+            .height(220.dp), factory = { context ->
             PieChart(context).apply { description.isEnabled = false }
         }, update = { chart ->
             val entries = state.priorityStats.map { PieEntry(it.value.toFloat(), it.key) }
@@ -45,5 +59,34 @@ fun StatsScreen(projectId: Long, projectName: String, viewModel: StatsViewModel)
             chart.data = PieData(dataSet)
             chart.invalidate()
         })
+        StatsListSection(title = "По приоритетам", stats = state.priorityStats, labelProvider = { formatPriorityLabel(it) })
     }
+}
+
+@Composable
+private fun StatsListSection(title: String, stats: List<StatsDto>, labelProvider: (String) -> String) {
+    Column {
+        Text(text = title, style = MaterialTheme.typography.titleMedium)
+        if (stats.isEmpty()) {
+            Text(text = "Нет данных")
+        } else {
+            stats.forEach { stat ->
+                Text(text = "${labelProvider(stat.key)}: ${stat.value}")
+            }
+        }
+    }
+}
+
+private fun formatStatusLabel(key: String): String = when (key) {
+    TaskStatus.TODO.name -> "Сделать"
+    TaskStatus.IN_PROGRESS.name -> "В работе"
+    TaskStatus.DONE.name -> "Готово"
+    else -> key
+}
+
+private fun formatPriorityLabel(key: String): String = when (key) {
+    TaskPriority.HIGH.name -> "Высокий"
+    TaskPriority.MEDIUM.name -> "Средний"
+    TaskPriority.LOW.name -> "Низкий"
+    else -> key
 }

--- a/android/app/src/main/java/com/example/minitasker/ui/screen/tasks/TasksScreen.kt
+++ b/android/app/src/main/java/com/example/minitasker/ui/screen/tasks/TasksScreen.kt
@@ -27,6 +27,8 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.example.minitasker.data.model.TaskPriority
+import com.example.minitasker.data.model.TaskStatus
 import com.example.minitasker.data.model.TaskSummaryDto
 
 @Composable
@@ -76,7 +78,7 @@ fun TasksScreen(
             }
         }
         Spacer(modifier = Modifier.height(12.dp))
-        Row {
+        Row { 
             androidx.compose.material3.OutlinedTextField(
                 value = newTaskTitle,
                 onValueChange = { newTaskTitle = it },
@@ -94,9 +96,42 @@ fun TasksScreen(
             }
         }
         Spacer(modifier = Modifier.height(12.dp))
+        Text(text = "Статус новой задачи", fontWeight = FontWeight.SemiBold)
+        Spacer(modifier = Modifier.height(4.dp))
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            FilterChip(label = "Сделать", selected = state.newTaskStatus == TaskStatus.TODO) {
+                viewModel.selectNewTaskStatus(TaskStatus.TODO)
+            }
+            FilterChip(label = "Готово", selected = state.newTaskStatus == TaskStatus.DONE) {
+                viewModel.selectNewTaskStatus(TaskStatus.DONE)
+            }
+        }
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(text = "Приоритет новой задачи", fontWeight = FontWeight.SemiBold)
+        Spacer(modifier = Modifier.height(4.dp))
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            FilterChip(label = "Низкий", selected = state.newTaskPriority == TaskPriority.LOW) {
+                viewModel.selectNewTaskPriority(TaskPriority.LOW)
+            }
+            FilterChip(label = "Средний", selected = state.newTaskPriority == TaskPriority.MEDIUM) {
+                viewModel.selectNewTaskPriority(TaskPriority.MEDIUM)
+            }
+            FilterChip(label = "Высокий", selected = state.newTaskPriority == TaskPriority.HIGH) {
+                viewModel.selectNewTaskPriority(TaskPriority.HIGH)
+            }
+        }
+        Spacer(modifier = Modifier.height(12.dp))
         LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp)) {
             items(state.items) { task ->
-                TaskItem(task = task, onClick = { onTaskSelected(task.id) })
+                TaskItem(
+                    task = task,
+                    onClick = { onTaskSelected(task.id) },
+                    onTakeTask = if (task.status == TaskStatus.TODO) {
+                        { viewModel.takeTask(projectId, task.id) }
+                    } else {
+                        null
+                    }
+                )
             }
         }
     }
@@ -114,7 +149,7 @@ private fun FilterChip(label: String, selected: Boolean, onClick: () -> Unit) {
 }
 
 @Composable
-private fun TaskItem(task: TaskSummaryDto, onClick: () -> Unit) {
+private fun TaskItem(task: TaskSummaryDto, onClick: () -> Unit, onTakeTask: (() -> Unit)? = null) {
     Card(
         modifier = Modifier
             .fillMaxWidth()
@@ -124,9 +159,27 @@ private fun TaskItem(task: TaskSummaryDto, onClick: () -> Unit) {
         Column(modifier = Modifier.padding(16.dp)) {
             Text(text = task.title, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
             Spacer(modifier = Modifier.height(4.dp))
-            Text(text = "Статус: ${task.status.name} | Приоритет: ${task.priority.name}")
+            Text(text = "Статус: ${task.status.toDisplayName()} | Приоритет: ${task.priority.toDisplayName()}")
             task.assigneeName?.let { Text(text = "Исполнитель: $it") }
             task.dueDate?.let { Text(text = "Срок: $it") }
+            onTakeTask?.let {
+                Spacer(modifier = Modifier.height(8.dp))
+                Button(onClick = it) {
+                    Text("Взять задачу")
+                }
+            }
         }
     }
+}
+
+private fun TaskStatus.toDisplayName(): String = when (this) {
+    TaskStatus.TODO -> "Сделать"
+    TaskStatus.IN_PROGRESS -> "В работе"
+    TaskStatus.DONE -> "Готово"
+}
+
+private fun TaskPriority.toDisplayName(): String = when (this) {
+    TaskPriority.LOW -> "Низкий"
+    TaskPriority.MEDIUM -> "Средний"
+    TaskPriority.HIGH -> "Высокий"
 }

--- a/android/app/src/main/java/com/example/minitasker/ui/screen/tasks/TasksViewModel.kt
+++ b/android/app/src/main/java/com/example/minitasker/ui/screen/tasks/TasksViewModel.kt
@@ -24,7 +24,9 @@ data class TasksUiState(
     val error: String? = null,
     val projectId: Long? = null,
     val status: TaskStatusFilter = TaskStatusFilter.ALL,
-    val priority: TaskPriorityFilter = TaskPriorityFilter.ALL
+    val priority: TaskPriorityFilter = TaskPriorityFilter.ALL,
+    val newTaskStatus: TaskStatus = TaskStatus.TODO,
+    val newTaskPriority: TaskPriority = TaskPriority.MEDIUM
 )
 
 class TasksViewModel(private val repository: TaskRepository) : ViewModel() {
@@ -66,15 +68,41 @@ class TasksViewModel(private val repository: TaskRepository) : ViewModel() {
         loadTasks(projectId)
     }
 
+    fun selectNewTaskStatus(status: TaskStatus) {
+        _state.value = _state.value.copy(newTaskStatus = status)
+    }
+
+    fun selectNewTaskPriority(priority: TaskPriority) {
+        _state.value = _state.value.copy(newTaskPriority = priority)
+    }
+
     fun createTask(projectId: Long, title: String) {
         viewModelScope.launch {
-            val request = TaskRequest(title, description = null, status = TaskStatus.TODO, priority = TaskPriority.MEDIUM, assigneeId = null, dueDate = null)
+            val currentState = _state.value
+            val request = TaskRequest(
+                title = title,
+                description = null,
+                status = currentState.newTaskStatus,
+                priority = currentState.newTaskPriority,
+                assigneeId = null,
+                dueDate = null
+            )
             when (safeCall { repository.createTask(projectId, request) }) {
                 is NetworkResult.Success -> {
                     _state.value = _state.value.copy(status = TaskStatusFilter.ALL)
                     loadTasks(projectId)
                 }
                 is NetworkResult.Error -> _state.value = _state.value.copy(error = "Не удалось создать задачу")
+                NetworkResult.Loading -> Unit
+            }
+        }
+    }
+
+    fun takeTask(projectId: Long, taskId: Long) {
+        viewModelScope.launch {
+            when (val result = safeCall { repository.takeTask(projectId, taskId) }) {
+                is NetworkResult.Success -> loadTasks(projectId)
+                is NetworkResult.Error -> _state.value = _state.value.copy(error = result.message)
                 NetworkResult.Loading -> Unit
             }
         }

--- a/backend/src/main/java/com/example/minitasker/controller/TaskController.java
+++ b/backend/src/main/java/com/example/minitasker/controller/TaskController.java
@@ -46,6 +46,12 @@ public class TaskController {
         return ResponseEntity.ok(taskService.createTask(projectId, request));
     }
 
+    @PostMapping("/projects/{projectId}/tasks/{taskId}/take")
+    public ResponseEntity<TaskResponse> takeTask(@PathVariable("projectId") Long projectId,
+                                                 @PathVariable("taskId") Long taskId) {
+        return ResponseEntity.ok(taskService.takeTask(projectId, taskId));
+    }
+
     @GetMapping("/tasks/{taskId}")
     public ResponseEntity<TaskResponse> getTask(@PathVariable("taskId") Long taskId) {
         return ResponseEntity.ok(taskService.getTask(taskId));

--- a/backend/src/main/java/com/example/minitasker/service/TaskService.java
+++ b/backend/src/main/java/com/example/minitasker/service/TaskService.java
@@ -11,5 +11,6 @@ public interface TaskService {
     TaskResponse getTask(Long id);
     TaskResponse createTask(Long projectId, TaskRequest request);
     TaskResponse updateTask(Long taskId, TaskRequest request);
+    TaskResponse takeTask(Long projectId, Long taskId);
     void deleteTask(Long id);
 }

--- a/backend/src/main/java/com/example/minitasker/service/impl/TaskServiceImpl.java
+++ b/backend/src/main/java/com/example/minitasker/service/impl/TaskServiceImpl.java
@@ -127,6 +127,28 @@ public class TaskServiceImpl implements TaskService {
     }
 
     @Override
+    public TaskResponse takeTask(Long projectId, Long taskId) {
+        Project project = loadProjectForCurrentUser(projectId);
+        Task task = taskRepository.findByIdAndProject(taskId, project)
+                .orElseThrow(() -> new ResourceNotFoundException("Task not found"));
+
+        if (task.getStatus() != TaskStatus.TODO) {
+            throw new BadRequestException("Task is not available for taking");
+        }
+
+        User current = SecurityUtils.getCurrentUser();
+        User assignee = userRepository.findById(current.getId())
+                .orElseThrow(() -> new ResourceNotFoundException("User not found"));
+
+        task.setStatus(TaskStatus.IN_PROGRESS);
+        task.setAssignee(assignee);
+
+        Task saved = taskRepository.save(task);
+        log.info("Task {} taken by {}", saved.getId(), assignee.getId());
+        return mapToResponse(saved);
+    }
+
+    @Override
     public void deleteTask(Long id) {
         Task task = loadTaskForCurrentUser(id);
         taskRepository.delete(task);


### PR DESCRIPTION
## Summary
- add a "take task" endpoint on the backend and hook it up to the Android client
- allow choosing status and priority when creating a task and update UI labels/actions
- expand the stats screen with textual breakdowns of statuses and priorities

## Testing
- mvn test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691aef6399988333bc1ff24a10f76610)