### PR TITLE
Enable shared workspace and refresh updates

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -88,5 +88,5 @@ dependencies {
 
     implementation("com.squareup.moshi:moshi-kotlin:1.15.1")
     implementation("androidx.compose.material:material-icons-extended")
-    implementation("androidx.compose.material:material-pull-refresh")
+    implementation("androidx.compose.material:material-pull-refresh:1.6.0")
 }

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -53,7 +53,7 @@ android {
 }
 
 dependencies {
-    val composeBom = platform("androidx.compose:compose-bom:2024.02.01")
+    val composeBom = platform("androidx.compose:compose-bom:2024.04.01")
 
     implementation(composeBom)
     androidTestImplementation(composeBom)
@@ -63,7 +63,8 @@ dependencies {
     implementation("androidx.activity:activity-compose:1.9.0")
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.ui:ui-tooling-preview")
-    implementation("androidx.compose.material3:material3:1.2.1")
+    implementation("androidx.compose.material3:material3")
+    implementation("androidx.compose.material:material")
     debugImplementation("androidx.compose.ui:ui-tooling")
     debugImplementation("androidx.compose.ui:ui-test-manifest")
 
@@ -88,5 +89,4 @@ dependencies {
 
     implementation("com.squareup.moshi:moshi-kotlin:1.15.1")
     implementation("androidx.compose.material:material-icons-extended")
-    implementation("androidx.compose.material:material-pull-refresh:1.6.0")
 }

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -88,4 +88,5 @@ dependencies {
 
     implementation("com.squareup.moshi:moshi-kotlin:1.15.1")
     implementation("androidx.compose.material:material-icons-extended")
+    implementation("androidx.compose.material:material-pull-refresh")
 }

--- a/android/app/src/main/java/com/example/minitasker/data/repository/ServiceLocator.kt
+++ b/android/app/src/main/java/com/example/minitasker/data/repository/ServiceLocator.kt
@@ -13,7 +13,7 @@ import retrofit2.converter.moshi.MoshiConverterFactory
 
 object ServiceLocator {
 
-    private const val BASE_URL = "http://45.155.207.118:9001"
+    const val BASE_URL = "http://45.155.207.118:9001"
 
     fun provideAuthPreferences(context: Context): AuthPreferences = AuthPreferences(context)
 
@@ -48,7 +48,7 @@ object ServiceLocator {
     }
 
     fun provideTaskRepository(context: Context): TaskRepository {
-        return TaskRepository(context, provideApiService(context))
+        return TaskRepository(context, provideApiService(context), BASE_URL)
     }
 
     fun provideStatsRepository(context: Context): StatsRepository {

--- a/android/app/src/main/java/com/example/minitasker/data/repository/TaskRepository.kt
+++ b/android/app/src/main/java/com/example/minitasker/data/repository/TaskRepository.kt
@@ -17,7 +17,11 @@ import okhttp3.MultipartBody
 import okhttp3.RequestBody
 import okhttp3.RequestBody.Companion.toRequestBody
 
-class TaskRepository(private val context: Context, private val apiService: ApiService) {
+class TaskRepository(
+    private val context: Context,
+    private val apiService: ApiService,
+    private val baseUrl: String
+) {
 
     suspend fun loadTasks(
         projectId: Long,
@@ -71,6 +75,15 @@ class TaskRepository(private val context: Context, private val apiService: ApiSe
         val requestBody: RequestBody = bytes.toRequestBody(mime.toMediaTypeOrNull())
         val part = MultipartBody.Part.createFormData("file", fileName, requestBody)
         return apiService.uploadAttachment(taskId, part)
+    }
+
+    fun resolveAttachmentUrl(attachment: AttachmentDto): String {
+        val url = attachment.url
+        return if (url.startsWith("http")) {
+            url
+        } else {
+            baseUrl.trimEnd('/') + url
+        }
     }
 
     private fun resolveFileName(resolver: ContentResolver, uri: Uri): String? {

--- a/android/app/src/main/java/com/example/minitasker/ui/screen/projects/ProjectsScreen.kt
+++ b/android/app/src/main/java/com/example/minitasker/ui/screen/projects/ProjectsScreen.kt
@@ -11,19 +11,25 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.pullrefresh.PullRefreshIndicator
+import androidx.compose.material.pullrefresh.pullRefresh
+import androidx.compose.material.pullrefresh.rememberPullRefreshState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Logout
 import androidx.compose.material.icons.filled.PieChart
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CenterAlignedTopAppBar
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -33,17 +39,19 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.launch
 import com.example.minitasker.data.model.ProjectDto
 import com.example.minitasker.ui.components.LabeledTextField
 import com.example.minitasker.ui.theme.MiniTaskerTheme
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterialApi::class)
 @Composable
 fun ProjectsScreen(
     viewModel: ProjectsViewModel,
@@ -54,9 +62,14 @@ fun ProjectsScreen(
     val state by viewModel.state.collectAsState()
     var projectName by remember { mutableStateOf("") }
     var projectDescription by remember { mutableStateOf("") }
+    val snackbarHostState = remember { SnackbarHostState() }
+    val scope = rememberCoroutineScope()
 
-    LaunchedEffect(Unit) {
-        viewModel.refresh()
+    LaunchedEffect(state.error) {
+        state.error?.let { message ->
+            scope.launch { snackbarHostState.showSnackbar(message) }
+            viewModel.clearError()
+        }
     }
 
     if (state.showCreateDialog) {
@@ -87,11 +100,14 @@ fun ProjectsScreen(
         onProjectSelected = onProjectSelected,
         onShowStats = onShowStats,
         onCreateProject = { viewModel.toggleCreateDialog(true) },
-        onLogout = { viewModel.logout(onLoggedOut) }
+        onLogout = { viewModel.logout(onLoggedOut) },
+        onDeleteProject = { viewModel.deleteProject(it) },
+        onRefresh = { viewModel.refresh() },
+        snackbarHostState = snackbarHostState
     )
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterialApi::class)
 @Composable
 private fun ProjectsScreenContent(
     state: ProjectsUiState,
@@ -99,7 +115,11 @@ private fun ProjectsScreenContent(
     onShowStats: (ProjectDto) -> Unit,
     onCreateProject: () -> Unit,
     onLogout: () -> Unit,
+    onDeleteProject: (Long) -> Unit,
+    onRefresh: () -> Unit,
+    snackbarHostState: SnackbarHostState,
 ) {
+    val refreshState = rememberPullRefreshState(refreshing = state.loading, onRefresh = onRefresh)
     Scaffold(
         containerColor = MaterialTheme.colorScheme.background,
         topBar = {
@@ -116,12 +136,14 @@ private fun ProjectsScreenContent(
             ExtendedFloatingActionButton(onClick = onCreateProject, text = { Text("Новый проект") }, icon = {
                 Icon(imageVector = Icons.Default.Add, contentDescription = null)
             })
-        }
+        },
+        snackbarHost = { SnackbarHost(hostState = snackbarHostState) }
     ) { paddingValues ->
         Box(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues)
+                .pullRefresh(refreshState)
         ) {
             LazyColumn(
                 modifier = Modifier.fillMaxSize(),
@@ -138,27 +160,45 @@ private fun ProjectsScreenContent(
                     }
                 }
                 items(state.projects, key = { it.id }) { project ->
-                    ProjectCard(project = project, onProjectSelected = onProjectSelected, onShowStats = onShowStats)
-                }
-                state.error?.let { errorMessage ->
-                    item {
-                        Text(
-                            text = errorMessage,
-                            color = MaterialTheme.colorScheme.error,
-                            style = MaterialTheme.typography.bodySmall
-                        )
-                    }
+                    ProjectCard(
+                        project = project,
+                        onProjectSelected = onProjectSelected,
+                        onShowStats = onShowStats,
+                        onDeleteProject = onDeleteProject
+                    )
                 }
             }
-            if (state.loading) {
-                CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
-            }
+            PullRefreshIndicator(refreshing = state.loading, state = refreshState, modifier = Modifier.align(Alignment.TopCenter))
         }
     }
 }
 
 @Composable
-private fun ProjectCard(project: ProjectDto, onProjectSelected: (ProjectDto) -> Unit, onShowStats: (ProjectDto) -> Unit) {
+private fun ProjectCard(
+    project: ProjectDto,
+    onProjectSelected: (ProjectDto) -> Unit,
+    onShowStats: (ProjectDto) -> Unit,
+    onDeleteProject: (Long) -> Unit
+) {
+    var showDeleteDialog by remember { mutableStateOf(false) }
+
+    if (showDeleteDialog) {
+        AlertDialog(
+            onDismissRequest = { showDeleteDialog = false },
+            confirmButton = {
+                TextButton(onClick = {
+                    onDeleteProject(project.id)
+                    showDeleteDialog = false
+                }) { Text("Удалить") }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDeleteDialog = false }) { Text("Отмена") }
+            },
+            title = { Text("Удалить проект?") },
+            text = { Text("Удалить проект вместе со всеми задачами?") }
+        )
+    }
+
     ElevatedCard(
         modifier = Modifier.fillMaxWidth(),
         shape = MaterialTheme.shapes.large,
@@ -180,7 +220,10 @@ private fun ProjectCard(project: ProjectDto, onProjectSelected: (ProjectDto) -> 
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
-            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+                IconButton(onClick = { showDeleteDialog = true }) {
+                    Icon(imageVector = Icons.Default.Delete, contentDescription = null)
+                }
                 TextButton(onClick = { onShowStats(project) }) {
                     Icon(imageVector = Icons.Default.PieChart, contentDescription = null)
                     Spacer(modifier = Modifier.width(4.dp))

--- a/android/app/src/main/java/com/example/minitasker/ui/screen/projects/ProjectsScreen.kt
+++ b/android/app/src/main/java/com/example/minitasker/ui/screen/projects/ProjectsScreen.kt
@@ -242,12 +242,16 @@ private fun ProjectsScreenPreview() {
             ProjectDto(1, "Новый маркетинг", "Запуск летней кампании", 1, "Анна", ""),
             ProjectDto(2, "Мобильное приложение", "Версия 2.0", 2, "Иван", "")
         )
+        val snackbarHostState = remember { SnackbarHostState() }
         ProjectsScreenContent(
             state = ProjectsUiState(projects = sampleProjects),
             onProjectSelected = {},
             onShowStats = {},
             onCreateProject = {},
-            onLogout = {}
+            onLogout = {},
+            onDeleteProject = {},
+            onRefresh = {},
+            snackbarHostState = snackbarHostState
         )
     }
 }

--- a/android/app/src/main/java/com/example/minitasker/ui/screen/projects/ProjectsViewModel.kt
+++ b/android/app/src/main/java/com/example/minitasker/ui/screen/projects/ProjectsViewModel.kt
@@ -63,6 +63,24 @@ class ProjectsViewModel(
         }
     }
 
+    fun deleteProject(id: Long) {
+        viewModelScope.launch {
+            _state.value = _state.value.copy(loading = true)
+            when (val result = safeCall { projectRepository.deleteProject(id) }) {
+                is NetworkResult.Success -> {
+                    val updated = _state.value.projects.filterNot { it.id == id }
+                    _state.value = _state.value.copy(projects = updated, loading = false)
+                }
+                is NetworkResult.Error -> _state.value = _state.value.copy(loading = false, error = result.message)
+                NetworkResult.Loading -> _state.value = _state.value.copy(loading = true)
+            }
+        }
+    }
+
+    fun clearError() {
+        _state.value = _state.value.copy(error = null)
+    }
+
     fun logout(onComplete: () -> Unit) {
         viewModelScope.launch {
             authRepository.logout()

--- a/android/app/src/main/java/com/example/minitasker/ui/screen/stats/StatsScreen.kt
+++ b/android/app/src/main/java/com/example/minitasker/ui/screen/stats/StatsScreen.kt
@@ -277,7 +277,8 @@ private fun StatsScreenPreview() {
             state = StatsUiState(
                 statusStats = statusStats,
                 priorityStats = priorityStats
-            )
+            ),
+            onRefresh = {}
         )
     }
 }

--- a/android/app/src/main/java/com/example/minitasker/ui/screen/stats/StatsScreen.kt
+++ b/android/app/src/main/java/com/example/minitasker/ui/screen/stats/StatsScreen.kt
@@ -12,8 +12,11 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.pullrefresh.PullRefreshIndicator
+import androidx.compose.material.pullrefresh.pullRefresh
+import androidx.compose.material.pullrefresh.rememberPullRefreshState
 import androidx.compose.material3.CenterAlignedTopAppBar
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -40,7 +43,7 @@ import com.github.mikephil.charting.data.PieData
 import com.github.mikephil.charting.data.PieDataSet
 import com.github.mikephil.charting.data.PieEntry
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterialApi::class)
 @Composable
 fun StatsScreen(
     projectId: Long,
@@ -55,16 +58,19 @@ fun StatsScreen(
 
     StatsScreenContent(
         projectName = projectName,
-        state = state
+        state = state,
+        onRefresh = { viewModel.load(projectId) }
     )
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterialApi::class)
 @Composable
 private fun StatsScreenContent(
     projectName: String,
-    state: StatsUiState
+    state: StatsUiState,
+    onRefresh: () -> Unit
 ) {
+    val refreshState = rememberPullRefreshState(refreshing = state.loading, onRefresh = onRefresh)
     Scaffold(
         containerColor = MaterialTheme.colorScheme.background,
         topBar = {
@@ -73,13 +79,17 @@ private fun StatsScreenContent(
             )
         }
     ) { paddingValues ->
-        LazyColumn(
+        Box(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(paddingValues),
-            contentPadding = PaddingValues(16.dp),
-            verticalArrangement = Arrangement.spacedBy(16.dp)
+                .padding(paddingValues)
+                .pullRefresh(refreshState)
         ) {
+            LazyColumn(
+                modifier = Modifier.fillMaxSize(),
+                contentPadding = PaddingValues(16.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
             item {
                 StatsCard(
                     title = "Статусы",
@@ -99,17 +109,6 @@ private fun StatsScreenContent(
                 )
             }
 
-            if (state.loading) {
-                item {
-                    Box(
-                        modifier = Modifier.fillMaxWidth(),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        CircularProgressIndicator()
-                    }
-                }
-            }
-
             state.error?.let { message ->
                 item {
                     Text(
@@ -118,6 +117,12 @@ private fun StatsScreenContent(
                     )
                 }
             }
+            }
+            PullRefreshIndicator(
+                refreshing = state.loading,
+                state = refreshState,
+                modifier = Modifier.align(Alignment.TopCenter)
+            )
         }
     }
 }

--- a/android/app/src/main/java/com/example/minitasker/ui/screen/taskdetail/TaskDetailScreen.kt
+++ b/android/app/src/main/java/com/example/minitasker/ui/screen/taskdetail/TaskDetailScreen.kt
@@ -1,7 +1,12 @@
 package com.example.minitasker.ui.screen.taskdetail
 
+import android.content.ActivityNotFoundException
+import android.content.Intent
+import android.net.Uri
+import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -39,6 +44,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -55,6 +61,7 @@ import com.example.minitasker.ui.theme.MiniTaskerTheme
 fun TaskDetailScreen(taskId: Long, viewModel: TaskDetailViewModel) {
     val state by viewModel.state.collectAsState()
     var commentText by remember { mutableStateOf("") }
+    val context = LocalContext.current
     val filePicker = rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri ->
         if (uri != null) {
             viewModel.uploadAttachment(taskId, uri)
@@ -85,7 +92,17 @@ fun TaskDetailScreen(taskId: Long, viewModel: TaskDetailViewModel) {
                 commentText = ""
             }
         },
-        onAttachClick = { filePicker.launch("*/*") }
+        onAttachClick = { filePicker.launch("*/*") },
+        onAttachmentClick = { attachment ->
+            val url = viewModel.resolveAttachmentUrl(attachment)
+            val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
+                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            try {
+                context.startActivity(intent)
+            } catch (e: ActivityNotFoundException) {
+                Toast.makeText(context, "Не удалось открыть файл", Toast.LENGTH_SHORT).show()
+            }
+        }
     )
 }
 
@@ -99,6 +116,7 @@ private fun TaskDetailContent(
     onPrioritySelected: (TaskPriority) -> Unit,
     onAddComment: () -> Unit,
     onAttachClick: () -> Unit,
+    onAttachmentClick: (AttachmentDto) -> Unit,
 ) {
     Scaffold(
         containerColor = MaterialTheme.colorScheme.background,
@@ -121,7 +139,11 @@ private fun TaskDetailContent(
                     CommentsCard(comments = task.comments)
                 }
                 item {
-                    AttachmentsCard(attachments = task.attachments, onAttachClick = onAttachClick)
+                    AttachmentsCard(
+                        attachments = task.attachments,
+                        onAttachClick = onAttachClick,
+                        onAttachmentClick = onAttachmentClick
+                    )
                 }
                 item {
                     CommentInputCard(commentText = commentText, onCommentTextChange = onCommentTextChange, onAddComment = onAddComment)
@@ -251,7 +273,11 @@ private fun CommentsCard(comments: List<CommentDto>) {
 }
 
 @Composable
-private fun AttachmentsCard(attachments: List<AttachmentDto>, onAttachClick: () -> Unit) {
+private fun AttachmentsCard(
+    attachments: List<AttachmentDto>,
+    onAttachClick: () -> Unit,
+    onAttachmentClick: (AttachmentDto) -> Unit
+) {
     ElevatedCard(shape = MaterialTheme.shapes.large) {
         Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
             Text(text = "Вложения", style = MaterialTheme.typography.titleMedium)
@@ -260,10 +286,19 @@ private fun AttachmentsCard(attachments: List<AttachmentDto>, onAttachClick: () 
             } else {
                 Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                     attachments.forEach { attachment ->
-                        Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                        Column(
+                            verticalArrangement = Arrangement.spacedBy(4.dp),
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable { onAttachmentClick(attachment) }
+                        ) {
                             Text(text = attachment.fileName, fontWeight = FontWeight.SemiBold)
                             Text(text = attachment.uploadedAt, style = MaterialTheme.typography.bodySmall)
-                            Text(text = attachment.url, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.primary)
+                            Text(
+                                text = attachment.contentType,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
                         }
                     }
                 }
@@ -356,7 +391,8 @@ private fun TaskDetailPreview() {
             onStatusSelected = {},
             onPrioritySelected = {},
             onAddComment = {},
-            onAttachClick = {}
+            onAttachClick = {},
+            onAttachmentClick = {}
         )
     }
 }

--- a/android/app/src/main/java/com/example/minitasker/ui/screen/taskdetail/TaskDetailViewModel.kt
+++ b/android/app/src/main/java/com/example/minitasker/ui/screen/taskdetail/TaskDetailViewModel.kt
@@ -3,6 +3,7 @@ package com.example.minitasker.ui.screen.taskdetail
 import android.net.Uri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.minitasker.data.model.AttachmentDto
 import com.example.minitasker.data.model.TaskRequest
 import com.example.minitasker.data.model.TaskResponseDto
 import com.example.minitasker.data.repository.NetworkResult
@@ -85,5 +86,9 @@ class TaskDetailViewModel(private val repository: TaskRepository) : ViewModel() 
                 NetworkResult.Loading -> Unit
             }
         }
+    }
+
+    fun resolveAttachmentUrl(attachment: AttachmentDto): String {
+        return repository.resolveAttachmentUrl(attachment)
     }
 }

--- a/android/app/src/main/java/com/example/minitasker/ui/screen/tasks/TasksScreen.kt
+++ b/android/app/src/main/java/com/example/minitasker/ui/screen/tasks/TasksScreen.kt
@@ -427,7 +427,8 @@ private fun TasksScreenPreview() {
             onTaskSelected = {},
             onTakeTask = {},
             onNewTaskStatusSelected = {},
-            onNewTaskPrioritySelected = {}
+            onNewTaskPrioritySelected = {},
+            onRefresh = {}
         )
     }
 }

--- a/android/app/src/main/java/com/example/minitasker/ui/screen/tasks/TasksScreen.kt
+++ b/android/app/src/main/java/com/example/minitasker/ui/screen/tasks/TasksScreen.kt
@@ -12,6 +12,10 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.pullrefresh.PullRefreshIndicator
+import androidx.compose.material.pullrefresh.pullRefresh
+import androidx.compose.material.pullrefresh.rememberPullRefreshState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CalendarToday
 import androidx.compose.material.icons.filled.Person
@@ -49,7 +53,7 @@ import com.example.minitasker.data.model.TaskStatus
 import com.example.minitasker.data.model.TaskSummaryDto
 import com.example.minitasker.ui.theme.MiniTaskerTheme
 
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class, ExperimentalMaterialApi::class)
 @Composable
 fun TasksScreen(
     projectId: Long,
@@ -80,11 +84,12 @@ fun TasksScreen(
         onTaskSelected = onTaskSelected,
         onTakeTask = { taskId -> viewModel.takeTask(projectId, taskId) },
         onNewTaskStatusSelected = viewModel::selectNewTaskStatus,
-        onNewTaskPrioritySelected = viewModel::selectNewTaskPriority
+        onNewTaskPrioritySelected = viewModel::selectNewTaskPriority,
+        onRefresh = { viewModel.loadTasks(projectId) }
     )
 }
 
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class, ExperimentalMaterialApi::class)
 @Composable
 private fun TasksScreenContent(
     projectName: String,
@@ -98,22 +103,28 @@ private fun TasksScreenContent(
     onTakeTask: (Long) -> Unit,
     onNewTaskStatusSelected: (TaskStatus) -> Unit,
     onNewTaskPrioritySelected: (TaskPriority) -> Unit,
+    onRefresh: () -> Unit,
 ) {
     val listState = rememberLazyListState()
+    val refreshState = rememberPullRefreshState(refreshing = state.loading, onRefresh = onRefresh)
     Scaffold(
         containerColor = MaterialTheme.colorScheme.background,
         topBar = {
             CenterAlignedTopAppBar(title = { Text("Задачи проекта $projectName") })
         }
     ) { paddingValues ->
-        LazyColumn(
+        Box(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(paddingValues),
-            state = listState,
-            verticalArrangement = Arrangement.spacedBy(12.dp),
-            contentPadding = androidx.compose.foundation.layout.PaddingValues(16.dp)
+                .padding(paddingValues)
+                .pullRefresh(refreshState)
         ) {
+            LazyColumn(
+                modifier = Modifier.fillMaxSize(),
+                state = listState,
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+                contentPadding = androidx.compose.foundation.layout.PaddingValues(16.dp)
+            ) {
             item {
                 FilterSection(
                     title = "Статусы",
@@ -167,22 +178,28 @@ private fun TasksScreenContent(
                     )
                 }
             }
-            items(state.items, key = { it.id }) { task ->
-                TaskItem(
-                    task = task,
-                    onClick = { onTaskSelected(task.id) },
-                    onTakeTask = if (task.status == TaskStatus.TODO) {
-                        { onTakeTask(task.id) }
-                    } else {
-                        null
+                items(state.items, key = { it.id }) { task ->
+                    TaskItem(
+                        task = task,
+                        onClick = { onTaskSelected(task.id) },
+                        onTakeTask = if (task.status == TaskStatus.TODO) {
+                            { onTakeTask(task.id) }
+                        } else {
+                            null
+                        }
+                    )
+                }
+                state.error?.let { message ->
+                    item {
+                        Text(text = message, color = MaterialTheme.colorScheme.error)
                     }
-                )
-            }
-            state.error?.let { message ->
-                item {
-                    Text(text = message, color = MaterialTheme.colorScheme.error)
                 }
             }
+            PullRefreshIndicator(
+                refreshing = state.loading,
+                state = refreshState,
+                modifier = Modifier.align(Alignment.TopCenter)
+            )
         }
     }
 }

--- a/backend/src/main/java/com/example/minitasker/controller/AttachmentController.java
+++ b/backend/src/main/java/com/example/minitasker/controller/AttachmentController.java
@@ -38,11 +38,18 @@ public class AttachmentController {
         return ResponseEntity.ok(attachmentService.uploadAttachment(taskId, file));
     }
 
-    @GetMapping("/attachments/{attachmentId}")
-    public ResponseEntity<Resource> downloadAttachment(@PathVariable("attachmentId") Long attachmentId) {
-        Resource resource = attachmentService.downloadAttachment(attachmentId);
+    @GetMapping("/tasks/{taskId}/attachments/{attachmentId}")
+    public ResponseEntity<Resource> downloadAttachment(@PathVariable("taskId") Long taskId,
+                                                       @PathVariable("attachmentId") Long attachmentId) {
+        var download = attachmentService.downloadAttachment(taskId, attachmentId);
+        MediaType mediaType = MediaType.APPLICATION_OCTET_STREAM;
+        if (download.getContentType() != null) {
+            mediaType = MediaType.parseMediaType(download.getContentType());
+        }
+        String fileName = download.getFileName() != null ? download.getFileName() : "attachment";
         return ResponseEntity.ok()
-                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=" + resource.getFilename())
-                .body(resource);
+                .contentType(mediaType)
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + fileName + "\"")
+                .body(download.getResource());
     }
 }

--- a/backend/src/main/java/com/example/minitasker/dto/attachment/AttachmentDownload.java
+++ b/backend/src/main/java/com/example/minitasker/dto/attachment/AttachmentDownload.java
@@ -1,0 +1,27 @@
+package com.example.minitasker.dto.attachment;
+
+import org.springframework.core.io.Resource;
+
+public class AttachmentDownload {
+    private final Resource resource;
+    private final String contentType;
+    private final String fileName;
+
+    public AttachmentDownload(Resource resource, String contentType, String fileName) {
+        this.resource = resource;
+        this.contentType = contentType;
+        this.fileName = fileName;
+    }
+
+    public Resource getResource() {
+        return resource;
+    }
+
+    public String getContentType() {
+        return contentType;
+    }
+
+    public String getFileName() {
+        return fileName;
+    }
+}

--- a/backend/src/main/java/com/example/minitasker/service/AttachmentService.java
+++ b/backend/src/main/java/com/example/minitasker/service/AttachmentService.java
@@ -9,5 +9,5 @@ import org.springframework.web.multipart.MultipartFile;
 public interface AttachmentService {
     List<AttachmentResponse> listAttachments(Long taskId);
     AttachmentResponse uploadAttachment(Long taskId, MultipartFile file) throws IOException;
-    Resource downloadAttachment(Long attachmentId);
+    AttachmentDownload downloadAttachment(Long taskId, Long attachmentId);
 }

--- a/backend/src/main/java/com/example/minitasker/service/impl/AttachmentServiceImpl.java
+++ b/backend/src/main/java/com/example/minitasker/service/impl/AttachmentServiceImpl.java
@@ -1,16 +1,14 @@
 package com.example.minitasker.service.impl;
 
+import com.example.minitasker.dto.attachment.AttachmentDownload;
 import com.example.minitasker.dto.attachment.AttachmentResponse;
 import com.example.minitasker.exception.BadRequestException;
 import com.example.minitasker.exception.ResourceNotFoundException;
 import com.example.minitasker.model.Attachment;
 import com.example.minitasker.model.Task;
-import com.example.minitasker.model.User;
-import com.example.minitasker.model.enums.Role;
 import com.example.minitasker.repository.AttachmentRepository;
 import com.example.minitasker.repository.TaskRepository;
 import com.example.minitasker.service.AttachmentService;
-import com.example.minitasker.util.SecurityUtils;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -70,30 +68,21 @@ public class AttachmentServiceImpl implements AttachmentService {
 
     @Override
     @Transactional(readOnly = true)
-    public Resource downloadAttachment(Long attachmentId) {
+    public AttachmentDownload downloadAttachment(Long taskId, Long attachmentId) {
+        Task task = loadTask(taskId);
         Attachment attachment = attachmentRepository.findById(attachmentId)
+                .filter(att -> att.getTask().getId().equals(task.getId()))
                 .orElseThrow(() -> new ResourceNotFoundException("Attachment not found"));
-        ensureTaskAccess(attachment.getTask());
-        return new FileSystemResource(Paths.get(attachment.getFilePath()));
+        return new AttachmentDownload(
+                new FileSystemResource(Paths.get(attachment.getFilePath())),
+                attachment.getContentType(),
+                attachment.getFileName()
+        );
     }
 
     private Task loadTask(Long id) {
-        Task task = taskRepository.findById(id)
+        return taskRepository.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException("Task not found"));
-        ensureTaskAccess(task);
-        return task;
-    }
-
-    private void ensureTaskAccess(Task task) {
-        User current = SecurityUtils.getCurrentUser();
-        if (current.getRole() == Role.ADMIN) {
-            return;
-        }
-        boolean owner = task.getProject().getOwner().getId().equals(current.getId());
-        boolean assigned = task.getAssignee() != null && task.getAssignee().getId().equals(current.getId());
-        if (!owner && !assigned) {
-            throw new ResourceNotFoundException("Task not found");
-        }
     }
 
     private AttachmentResponse mapToDto(Attachment attachment) {
@@ -102,7 +91,7 @@ public class AttachmentServiceImpl implements AttachmentService {
         response.setTaskId(attachment.getTask().getId());
         response.setFileName(attachment.getFileName());
         response.setContentType(attachment.getContentType());
-        response.setUrl("/api/attachments/" + attachment.getId());
+        response.setUrl("/api/tasks/" + attachment.getTask().getId() + "/attachments/" + attachment.getId());
         response.setUploadedAt(attachment.getUploadedAt());
         return response;
     }

--- a/backend/src/main/java/com/example/minitasker/service/impl/ProjectServiceImpl.java
+++ b/backend/src/main/java/com/example/minitasker/service/impl/ProjectServiceImpl.java
@@ -6,7 +6,6 @@ import com.example.minitasker.dto.project.ProjectResponse;
 import com.example.minitasker.exception.ResourceNotFoundException;
 import com.example.minitasker.model.Project;
 import com.example.minitasker.model.User;
-import com.example.minitasker.model.enums.Role;
 import com.example.minitasker.repository.ProjectRepository;
 import com.example.minitasker.repository.UserRepository;
 import com.example.minitasker.service.ProjectService;
@@ -36,20 +35,11 @@ public class ProjectServiceImpl implements ProjectService {
     @Override
     @Transactional(readOnly = true)
     public PageResponse<ProjectResponse> getProjects(String nameFilter, Pageable pageable) {
-        User current = SecurityUtils.getCurrentUser();
         Page<Project> page;
-        if (current.getRole() == Role.ADMIN) {
-            if (nameFilter != null && !nameFilter.isBlank()) {
-                page = projectRepository.findByNameContainingIgnoreCase(nameFilter, pageable);
-            } else {
-                page = projectRepository.findAll(pageable);
-            }
+        if (nameFilter != null && !nameFilter.isBlank()) {
+            page = projectRepository.findByNameContainingIgnoreCase(nameFilter, pageable);
         } else {
-            if (nameFilter != null && !nameFilter.isBlank()) {
-                page = projectRepository.findByOwnerAndNameContainingIgnoreCase(current, nameFilter, pageable);
-            } else {
-                page = projectRepository.findByOwner(current, pageable);
-            }
+            page = projectRepository.findAll(pageable);
         }
         return new PageResponse<>(
                 page.map(this::mapToDto).getContent(),
@@ -62,7 +52,7 @@ public class ProjectServiceImpl implements ProjectService {
     @Override
     @Transactional(readOnly = true)
     public ProjectResponse getProject(Long id) {
-        Project project = loadProjectForCurrentUser(id);
+        Project project = loadProject(id);
         return mapToDto(project);
     }
 
@@ -80,7 +70,7 @@ public class ProjectServiceImpl implements ProjectService {
 
     @Override
     public ProjectResponse updateProject(Long id, ProjectRequest request) {
-        Project project = loadProjectForCurrentUser(id);
+        Project project = loadProject(id);
         project.setName(request.getName());
         project.setDescription(request.getDescription());
         Project updated = projectRepository.save(project);
@@ -90,18 +80,13 @@ public class ProjectServiceImpl implements ProjectService {
 
     @Override
     public void deleteProject(Long id) {
-        Project project = loadProjectForCurrentUser(id);
+        Project project = loadProject(id);
         projectRepository.delete(project);
         log.info("Project deleted: {}", project.getId());
     }
 
-    private Project loadProjectForCurrentUser(Long id) {
-        User current = SecurityUtils.getCurrentUser();
-        if (current.getRole() == Role.ADMIN) {
-            return projectRepository.findById(id)
-                    .orElseThrow(() -> new ResourceNotFoundException("Project not found"));
-        }
-        return projectRepository.findByIdAndOwner(id, current)
+    private Project loadProject(Long id) {
+        return projectRepository.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException("Project not found"));
     }
 

--- a/backend/src/main/java/com/example/minitasker/service/impl/StatsServiceImpl.java
+++ b/backend/src/main/java/com/example/minitasker/service/impl/StatsServiceImpl.java
@@ -3,15 +3,11 @@ package com.example.minitasker.service.impl;
 import com.example.minitasker.dto.stats.KeyValueStat;
 import com.example.minitasker.exception.ResourceNotFoundException;
 import com.example.minitasker.model.Project;
-import com.example.minitasker.model.Task;
-import com.example.minitasker.model.User;
-import com.example.minitasker.model.enums.Role;
 import com.example.minitasker.model.enums.TaskPriority;
 import com.example.minitasker.model.enums.TaskStatus;
 import com.example.minitasker.repository.ProjectRepository;
 import com.example.minitasker.repository.TaskRepository;
 import com.example.minitasker.service.StatsService;
-import com.example.minitasker.util.SecurityUtils;
 import java.util.ArrayList;
 import java.util.List;
 import org.springframework.stereotype.Service;
@@ -52,24 +48,7 @@ public class StatsServiceImpl implements StatsService {
     }
 
     private Project loadProject(Long projectId) {
-        Project project = projectRepository.findById(projectId)
+        return projectRepository.findById(projectId)
                 .orElseThrow(() -> new ResourceNotFoundException("Project not found"));
-        ensureAccess(project);
-        return project;
-    }
-
-    private void ensureAccess(Project project) {
-        User current = SecurityUtils.getCurrentUser();
-        if (current.getRole() == Role.ADMIN) {
-            return;
-        }
-        boolean owner = project.getOwner().getId().equals(current.getId());
-        boolean assigned = project.getTasks().stream()
-                .map(Task::getAssignee)
-                .filter(a -> a != null)
-                .anyMatch(a -> a.getId().equals(current.getId()));
-        if (!owner && !assigned) {
-            throw new ResourceNotFoundException("Project not found");
-        }
     }
 }

--- a/backend/src/main/java/com/example/minitasker/service/impl/TaskServiceImpl.java
+++ b/backend/src/main/java/com/example/minitasker/service/impl/TaskServiceImpl.java
@@ -11,7 +11,6 @@ import com.example.minitasker.model.Comment;
 import com.example.minitasker.model.Project;
 import com.example.minitasker.model.Task;
 import com.example.minitasker.model.User;
-import com.example.minitasker.model.enums.Role;
 import com.example.minitasker.model.enums.TaskPriority;
 import com.example.minitasker.model.enums.TaskStatus;
 import com.example.minitasker.repository.CommentRepository;
@@ -58,7 +57,7 @@ public class TaskServiceImpl implements TaskService {
                                               String priority,
                                               Long assigneeId,
                                               Pageable pageable) {
-        Project project = loadProjectForCurrentUser(projectId);
+        Project project = loadProject(projectId);
         Specification<Task> spec = Specification.where(
                 (root, query, cb) -> cb.equal(root.get("project"), project)
         );
@@ -102,13 +101,13 @@ public class TaskServiceImpl implements TaskService {
     @Override
     @Transactional(readOnly = true)
     public TaskResponse getTask(Long id) {
-        Task task = loadTaskForCurrentUser(id);
+        Task task = loadTask(id);
         return mapToResponse(task);
     }
 
     @Override
     public TaskResponse createTask(Long projectId, TaskRequest request) {
-        Project project = loadProjectForCurrentUser(projectId);
+        Project project = loadProject(projectId);
         Task task = new Task();
         task.setProject(project);
         applyTaskRequest(task, request);
@@ -119,7 +118,7 @@ public class TaskServiceImpl implements TaskService {
 
     @Override
     public TaskResponse updateTask(Long taskId, TaskRequest request) {
-        Task task = loadTaskForCurrentUser(taskId);
+        Task task = loadTask(taskId);
         applyTaskRequest(task, request);
         Task updated = taskRepository.save(task);
         log.info("Task updated: {}", updated.getId());
@@ -128,7 +127,7 @@ public class TaskServiceImpl implements TaskService {
 
     @Override
     public TaskResponse takeTask(Long projectId, Long taskId) {
-        Project project = loadProjectForCurrentUser(projectId);
+        Project project = loadProject(projectId);
         Task task = taskRepository.findByIdAndProject(taskId, project)
                 .orElseThrow(() -> new ResourceNotFoundException("Task not found"));
 
@@ -136,8 +135,7 @@ public class TaskServiceImpl implements TaskService {
             throw new BadRequestException("Task is not available for taking");
         }
 
-        User current = SecurityUtils.getCurrentUser();
-        User assignee = userRepository.findById(current.getId())
+        User assignee = userRepository.findById(SecurityUtils.getCurrentUser().getId())
                 .orElseThrow(() -> new ResourceNotFoundException("User not found"));
 
         task.setStatus(TaskStatus.IN_PROGRESS);
@@ -150,7 +148,7 @@ public class TaskServiceImpl implements TaskService {
 
     @Override
     public void deleteTask(Long id) {
-        Task task = loadTaskForCurrentUser(id);
+        Task task = loadTask(id);
         taskRepository.delete(task);
         log.info("Task deleted: {}", task.getId());
     }
@@ -172,35 +170,14 @@ public class TaskServiceImpl implements TaskService {
         task.setDueDate(request.getDueDate());
     }
 
-    private Task loadTaskForCurrentUser(Long id) {
-        Task task = taskRepository.findById(id)
+    private Task loadTask(Long id) {
+        return taskRepository.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException("Task not found"));
-        ensureAccessToProject(task.getProject());
-        return task;
     }
 
-    private Project loadProjectForCurrentUser(Long projectId) {
-        Project project = projectRepository.findById(projectId)
+    private Project loadProject(Long projectId) {
+        return projectRepository.findById(projectId)
                 .orElseThrow(() -> new ResourceNotFoundException("Project not found"));
-        ensureAccessToProject(project);
-        return project;
-    }
-
-    private void ensureAccessToProject(Project project) {
-        User current = SecurityUtils.getCurrentUser();
-        if (current.getRole() == Role.ADMIN) {
-            return;
-        }
-
-        boolean owner = project.getOwner().getId().equals(current.getId());
-        boolean assignee = project.getTasks().stream()
-                .map(Task::getAssignee)
-                .filter(a -> a != null)
-                .anyMatch(a -> a.getId().equals(current.getId()));
-
-        if (!owner && !assignee) {
-            throw new ResourceNotFoundException("Project not found");
-        }
     }
 
     private TaskSummary mapToSummary(Task task) {
@@ -261,7 +238,7 @@ public class TaskServiceImpl implements TaskService {
                             dto.setFileName(attachment.getFileName());
                             dto.setContentType(attachment.getContentType());
                             dto.setUploadedAt(attachment.getUploadedAt());
-                            dto.setUrl("/api/attachments/" + attachment.getId());
+                            dto.setUrl("/api/tasks/" + task.getId() + "/attachments/" + attachment.getId());
                             return dto;
                         })
                         .collect(Collectors.toList())


### PR DESCRIPTION
## Summary
- remove owner-based access checks so all authenticated users can view projects, tasks, and stats while keeping project ownership metadata
- add attachment download support with per-task endpoints and expose download URLs to the Android client
- implement pull-to-refresh, project deletion with confirmation, and attachment opening in the Android app

## Testing
- ⚠️ `./gradlew backend:test` *(wrapper not available at repository root)*
- ⚠️ `./gradlew app:assembleDebug` *(Gradle wrapper missing GradleWrapperMain in android module)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ec7266e688333a7d29782cf429835)