### PR TITLE
Fix compose pull refresh dependency for release build

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -53,7 +53,7 @@ android {
 }
 
 dependencies {
-    val composeBom = platform("androidx.compose:compose-bom:2024.02.01")
+    val composeBom = platform("androidx.compose:compose-bom:2024.04.01")
 
     implementation(composeBom)
     androidTestImplementation(composeBom)
@@ -63,7 +63,8 @@ dependencies {
     implementation("androidx.activity:activity-compose:1.9.0")
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.ui:ui-tooling-preview")
-    implementation("androidx.compose.material3:material3:1.2.1")
+    implementation("androidx.compose.material3:material3")
+    implementation("androidx.compose.material:material")
     debugImplementation("androidx.compose.ui:ui-tooling")
     debugImplementation("androidx.compose.ui:ui-test-manifest")
 
@@ -88,5 +89,4 @@ dependencies {
 
     implementation("com.squareup.moshi:moshi-kotlin:1.15.1")
     implementation("androidx.compose.material:material-icons-extended")
-    implementation("androidx.compose.material:material-pull-refresh:1.6.0")
 }


### PR DESCRIPTION
## Summary
- replace the missing material-pull-refresh artifact with the standard Compose material dependency
- update the Compose BOM version and rely on BOM-managed artifacts for material3/material usage

## Testing
- Not run (please verify with `cd android && ./gradlew :app:assembleRelease`)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ed35d57788333b87ba9d0169718f4)