### PR TITLE
Fix missing parameters in screen previews

### DIFF
--- a/android/app/src/main/java/com/example/minitasker/ui/screen/projects/ProjectsScreen.kt
+++ b/android/app/src/main/java/com/example/minitasker/ui/screen/projects/ProjectsScreen.kt
@@ -242,12 +242,16 @@ private fun ProjectsScreenPreview() {
             ProjectDto(1, "Новый маркетинг", "Запуск летней кампании", 1, "Анна", ""),
             ProjectDto(2, "Мобильное приложение", "Версия 2.0", 2, "Иван", "")
         )
+        val snackbarHostState = remember { SnackbarHostState() }
         ProjectsScreenContent(
             state = ProjectsUiState(projects = sampleProjects),
             onProjectSelected = {},
             onShowStats = {},
             onCreateProject = {},
-            onLogout = {}
+            onLogout = {},
+            onDeleteProject = {},
+            onRefresh = {},
+            snackbarHostState = snackbarHostState
         )
     }
 }

--- a/android/app/src/main/java/com/example/minitasker/ui/screen/stats/StatsScreen.kt
+++ b/android/app/src/main/java/com/example/minitasker/ui/screen/stats/StatsScreen.kt
@@ -277,7 +277,8 @@ private fun StatsScreenPreview() {
             state = StatsUiState(
                 statusStats = statusStats,
                 priorityStats = priorityStats
-            )
+            ),
+            onRefresh = {}
         )
     }
 }

--- a/android/app/src/main/java/com/example/minitasker/ui/screen/tasks/TasksScreen.kt
+++ b/android/app/src/main/java/com/example/minitasker/ui/screen/tasks/TasksScreen.kt
@@ -427,7 +427,8 @@ private fun TasksScreenPreview() {
             onTaskSelected = {},
             onTakeTask = {},
             onNewTaskStatusSelected = {},
-            onNewTaskPrioritySelected = {}
+            onNewTaskPrioritySelected = {},
+            onRefresh = {}
         )
     }
 }


### PR DESCRIPTION
## Summary
- add snackbar host state and callback stubs to projects screen preview
- supply refresh callback stub in stats screen preview
- add refresh callback stub in tasks screen preview

## Testing
- ./gradlew :app:assembleRelease *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ed9ab6f188333a26b5ad2214cf0ea)