### PR TITLE
Fix AttachmentDownload import in AttachmentService

### DIFF
--- a/backend/src/main/java/com/example/minitasker/service/AttachmentService.java
+++ b/backend/src/main/java/com/example/minitasker/service/AttachmentService.java
@@ -1,9 +1,9 @@
 package com.example.minitasker.service;
 
+import com.example.minitasker.dto.attachment.AttachmentDownload;
 import com.example.minitasker.dto.attachment.AttachmentResponse;
 import java.io.IOException;
 import java.util.List;
-import org.springframework.core.io.Resource;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface AttachmentService {


### PR DESCRIPTION
## Summary
- add the missing AttachmentDownload DTO import to the attachment service interface to align with implementation

## Testing
- mvn -B -DskipTests clean package

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691edd3881bc8333a2944643ac181597)