### PR TITLE
Handle missing download url for attachments

### DIFF
--- a/android/app/src/main/java/com/example/minitasker/data/model/TaskModels.kt
+++ b/android/app/src/main/java/com/example/minitasker/data/model/TaskModels.kt
@@ -56,7 +56,7 @@ data class AttachmentDto(
     val fileName: String,
     val contentType: String,
     val url: String?,
-    val downloadUrl: String,
+    val downloadUrl: String? = null,
     val uploadedAt: String
 )
 

--- a/android/app/src/main/java/com/example/minitasker/data/repository/TaskRepository.kt
+++ b/android/app/src/main/java/com/example/minitasker/data/repository/TaskRepository.kt
@@ -81,7 +81,10 @@ class TaskRepository(
     }
 
     fun resolveAttachmentUrl(attachment: AttachmentDto): String {
-        val url = attachment.downloadUrl.ifBlank { attachment.url.orEmpty() }
+        val url = attachment.downloadUrl?.takeIf { it.isNotBlank() }
+            ?: attachment.url?.takeIf { it.isNotBlank() }
+            ?: "/api/tasks/${attachment.taskId ?: ""}/attachments/${attachment.id}"
+
         return if (url.startsWith("http")) {
             url
         } else {


### PR DESCRIPTION
## Summary
- make attachment download URLs nullable to tolerate missing fields from backend
- build download links with a fallback based on task and attachment identifiers when no direct URL is provided

## Testing
- gradle assembleDebug (fails: Android SDK not configured in environment)
- gradle assembleRelease (fails: Android SDK not configured in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691eedc14fa483338a70a899c569beef)