### PR TITLE
Fix attachment download error handling

### DIFF
--- a/backend/src/main/java/com/example/minitasker/controller/AttachmentController.java
+++ b/backend/src/main/java/com/example/minitasker/controller/AttachmentController.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.util.List;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.InvalidMediaTypeException;
 import org.springframework.http.MediaType;
 import org.springframework.http.MediaTypeFactory;
 import org.springframework.http.ResponseEntity;
@@ -56,7 +57,11 @@ public class AttachmentController {
         var download = attachmentService.downloadAttachment(taskId, attachmentId);
         MediaType mediaType = MediaType.APPLICATION_OCTET_STREAM;
         if (StringUtils.hasText(download.getContentType())) {
-            mediaType = MediaType.parseMediaType(download.getContentType());
+            try {
+                mediaType = MediaType.parseMediaType(download.getContentType());
+            } catch (InvalidMediaTypeException ignored) {
+                mediaType = MediaType.APPLICATION_OCTET_STREAM;
+            }
         } else if (StringUtils.hasText(download.getFileName())) {
             mediaType = MediaTypeFactory.getMediaType(download.getFileName())
                     .orElse(MediaType.APPLICATION_OCTET_STREAM);

--- a/backend/src/main/java/com/example/minitasker/service/impl/AttachmentServiceImpl.java
+++ b/backend/src/main/java/com/example/minitasker/service/impl/AttachmentServiceImpl.java
@@ -76,7 +76,14 @@ public class AttachmentServiceImpl implements AttachmentService {
         Attachment attachment = attachmentRepository.findById(attachmentId)
                 .filter(att -> att.getTask().getId().equals(task.getId()))
                 .orElseThrow(() -> new ResourceNotFoundException("Attachment not found"));
-        Resource resource = new FileSystemResource(Paths.get(attachment.getFilePath()));
+        Path filePath = Paths.get(attachment.getFilePath()).normalize();
+        if (!filePath.toAbsolutePath().startsWith(storagePath)) {
+            throw new ResourceNotFoundException("Attachment not found");
+        }
+        Resource resource = new FileSystemResource(filePath);
+        if (!resource.exists() || !resource.isReadable()) {
+            throw new ResourceNotFoundException("Attachment file not found");
+        }
         Long contentLength = null;
         try {
             contentLength = resource.contentLength();


### PR DESCRIPTION
## Summary
- guard attachment downloads against missing files or invalid storage paths and return 404 instead of 500
- fall back to a safe media type when parsing stored content types for downloads

## Testing
- ./gradlew test (fails: No such file or directory)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ef2ed6ac08333954a3b9092edb2d6)