### PR TITLE
Configure persistent attachment storage and download URLs

### DIFF
--- a/android/app/src/main/java/com/example/minitasker/data/model/TaskModels.kt
+++ b/android/app/src/main/java/com/example/minitasker/data/model/TaskModels.kt
@@ -56,7 +56,7 @@ data class AttachmentDto(
     val fileName: String,
     val contentType: String,
     val url: String?,
-    val downloadUrl: String? = null,
+    val downloadUrl: String,
     val uploadedAt: String
 )
 

--- a/android/app/src/main/java/com/example/minitasker/data/repository/TaskRepository.kt
+++ b/android/app/src/main/java/com/example/minitasker/data/repository/TaskRepository.kt
@@ -81,15 +81,11 @@ class TaskRepository(
     }
 
     fun resolveAttachmentUrl(attachment: AttachmentDto): String {
-        val url = attachment.downloadUrl?.takeIf { it.isNotBlank() }
-            ?: attachment.url?.takeIf { it.isNotBlank() }
-            ?: "/api/tasks/${attachment.taskId ?: ""}/attachments/${attachment.id}"
-
-        return if (url.startsWith("http")) {
-            url
-        } else {
-            baseUrl.trimEnd('/') + url
+        val url = attachment.downloadUrl
+        if (url.isBlank()) {
+            throw IllegalArgumentException("Ссылка для скачивания отсутствует")
         }
+        return if (url.startsWith("http")) url else baseUrl.trimEnd('/') + url
     }
 
     suspend fun downloadAttachment(attachment: AttachmentDto): String {

--- a/backend/src/main/java/com/example/minitasker/model/Attachment.java
+++ b/backend/src/main/java/com/example/minitasker/model/Attachment.java
@@ -21,8 +21,8 @@ public class Attachment {
     @Column(nullable = false)
     private String contentType;
 
-    @Column(nullable = false)
-    private String filePath;
+    @Column(name = "storage_filename", nullable = false)
+    private String storageFileName;
 
     @Column(nullable = false)
     private OffsetDateTime uploadedAt = OffsetDateTime.now();
@@ -59,12 +59,12 @@ public class Attachment {
         this.contentType = contentType;
     }
 
-    public String getFilePath() {
-        return filePath;
+    public String getStorageFileName() {
+        return storageFileName;
     }
 
-    public void setFilePath(String filePath) {
-        this.filePath = filePath;
+    public void setStorageFileName(String storageFileName) {
+        this.storageFileName = storageFileName;
     }
 
     public OffsetDateTime getUploadedAt() {

--- a/backend/src/main/java/com/example/minitasker/service/impl/AttachmentServiceImpl.java
+++ b/backend/src/main/java/com/example/minitasker/service/impl/AttachmentServiceImpl.java
@@ -16,7 +16,9 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
@@ -24,6 +26,7 @@ import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import org.springframework.web.multipart.MultipartFile;
 
 @Service
@@ -36,10 +39,15 @@ public class AttachmentServiceImpl implements AttachmentService {
 
     public AttachmentServiceImpl(AttachmentRepository attachmentRepository,
                                  TaskRepository taskRepository,
-                                 @Value("${minitasker.storage.upload-dir}") String uploadDir) {
+                                 @Value("${minitasker.attachments-dir:/data/attachments}") String attachmentsDir) {
         this.attachmentRepository = attachmentRepository;
         this.taskRepository = taskRepository;
-        this.storagePath = Paths.get(uploadDir).toAbsolutePath().normalize();
+        this.storagePath = Paths.get(attachmentsDir).toAbsolutePath().normalize();
+        try {
+            Files.createDirectories(this.storagePath);
+        } catch (IOException e) {
+            throw new IllegalStateException("Unable to initialize attachments directory", e);
+        }
     }
 
     @Override
@@ -57,14 +65,17 @@ public class AttachmentServiceImpl implements AttachmentService {
             throw new BadRequestException("File is empty");
         }
         Task task = loadTask(taskId);
-        String filename = System.currentTimeMillis() + "_" + file.getOriginalFilename();
-        Path destination = storagePath.resolve(filename);
-        Files.copy(file.getInputStream(), destination);
+        String originalName = file.getOriginalFilename();
+        String extension = org.springframework.util.StringUtils.getFilenameExtension(originalName);
+        String storageFileName = UUID.randomUUID()
+                + (StringUtils.isNotBlank(extension) ? "." + extension : "");
+        Path destination = storagePath.resolve(storageFileName);
+        Files.copy(file.getInputStream(), destination, StandardCopyOption.REPLACE_EXISTING);
         Attachment attachment = new Attachment();
         attachment.setTask(task);
-        attachment.setFileName(file.getOriginalFilename());
+        attachment.setFileName(originalName);
         attachment.setContentType(file.getContentType() != null ? file.getContentType() : "application/octet-stream");
-        attachment.setFilePath(destination.toString());
+        attachment.setStorageFileName(storageFileName);
         Attachment saved = attachmentRepository.save(attachment);
         return mapToDto(saved);
     }
@@ -76,10 +87,7 @@ public class AttachmentServiceImpl implements AttachmentService {
         Attachment attachment = attachmentRepository.findById(attachmentId)
                 .filter(att -> att.getTask().getId().equals(task.getId()))
                 .orElseThrow(() -> new ResourceNotFoundException("Attachment not found"));
-        Path filePath = Paths.get(attachment.getFilePath()).normalize();
-        if (!filePath.toAbsolutePath().startsWith(storagePath)) {
-            throw new ResourceNotFoundException("Attachment not found");
-        }
+        Path filePath = storagePath.resolve(attachment.getStorageFileName()).normalize();
         Resource resource = new FileSystemResource(filePath);
         if (!resource.exists() || !resource.isReadable()) {
             throw new ResourceNotFoundException("Attachment file not found");
@@ -119,8 +127,15 @@ public class AttachmentServiceImpl implements AttachmentService {
         response.setFileName(attachment.getFileName());
         response.setContentType(attachment.getContentType());
         String downloadPath = "/api/tasks/" + attachment.getTask().getId() + "/attachments/" + attachment.getId();
-        response.setUrl(downloadPath);
-        response.setDownloadUrl(downloadPath + "/download");
+        response.setUrl(ServletUriComponentsBuilder.fromCurrentContextPath()
+                .path(downloadPath)
+                .build()
+                .toUriString());
+        response.setDownloadUrl(ServletUriComponentsBuilder.fromCurrentContextPath()
+                .path(downloadPath)
+                .path("/download")
+                .build()
+                .toUriString());
         response.setUploadedAt(attachment.getUploadedAt());
         return response;
     }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -25,8 +25,7 @@ minitasker:
   security:
     jwt-secret: change-me-please-change-me-please-change-me-please
     jwt-expiration-minutes: 60
-  storage:
-    upload-dir: ./uploads
+  attachments-dir: /data/attachments
 
 server:
   address: 0.0.0.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,8 @@ services:
       SPRING_DATASOURCE_PASSWORD: postgres
     ports:
       - "9001:9001"
+    volumes:
+      - ./attachments:/data/attachments
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
## Summary
- store attachments in a dedicated /data/attachments directory and persist storage filenames
- expose stable download URLs from the backend and include them in attachment responses
- update Android attachment downloads to consume the provided downloadUrl and persist files via docker volume

## Testing
- mvn test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ef845d8ac8333a06aac830f4304ec)